### PR TITLE
[fix] Prevent ephemeral file paths from leaking into commit messages

### DIFF
--- a/skills/commit-msg/SKILL.md
+++ b/skills/commit-msg/SKILL.md
@@ -56,6 +56,7 @@ Benefits:
 4. **Length**: Keep under 15 lines total
 5. **No file lists**: Redundant with the diff
 6. **No line wrapping at 80 columns**: Use natural line breaks only
+7. **No ephemeral file paths**: Never reference `.scratchpads/`, `.claude-questions/`, `.commit-msgs/`, or `.breadcrumbs/` paths — these are local working files that don't exist on GitHub
 
 ### Good Example
 

--- a/skills/tackle-scratchpad-block/SKILL.md
+++ b/skills/tackle-scratchpad-block/SKILL.md
@@ -61,7 +61,8 @@ Include context from:
 
 - The scratchpad's goal/issue number
 - What was implemented in this block
-- Reference to the scratchpad file
+
+**Do NOT reference the scratchpad file path** in the commit message — it's an ephemeral local file that doesn't exist on GitHub.
 
 ## Step 6: Report Status and STOP
 


### PR DESCRIPTION
Scratchpad and question file paths were appearing in commit messages because nothing in the commit-msg skill prohibited them. finish-issue already had this guard for PR descriptions, but commit-msg (the foundational skill all others delegate to) did not.

Benefits:
- commit-msg skill now explicitly prohibits ephemeral paths as a format rule
- tackle-scratchpad-block no longer encourages referencing the scratchpad file
- Guard is at the source — all skills that delegate to /commit-msg inherit it