### PR TITLE
[feat] Auto-manage .gitignore entries for ephemeral skill directories

### DIFF
--- a/skills/issue-context/SKILL.md
+++ b/skills/issue-context/SKILL.md
@@ -100,7 +100,7 @@ The `/breadcrumb` skill handles this directly, but still uses issue-context for 
 
 ## Ensure `.gitignore`
 
-Before creating any ephemeral file, ensure the project's `.gitignore` includes entries for all skill working directories. This prevents SCM noise in consuming projects.
+Foundation skills already consult issue-context for directory placement — this check runs as part of that same consultation. Before creating any ephemeral file, ensure the project's `.gitignore` includes entries for all skill working directories. This prevents SCM noise in consuming projects.
 
 1. Read `.gitignore` in the project root (if it doesn't exist, treat contents as empty)
 2. Check if the sentinel comment `# Claude skill working directories` is present


### PR DESCRIPTION
Skill working directories (.scratchpads/, .claude-questions/, .commit-msgs/, .breadcrumbs/) pollute git status in consuming projects. Adding .gitignore management to issue-context means all foundation skills get it for free with zero duplication — the logic lives in one place that every skill already consults before creating files.

Benefits:
- Ephemeral directories stay out of SCM automatically
- Idempotent — sentinel comment prevents duplicate entries
- Single source of truth in issue-context, no copy-pasta across skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated skill docs to reflect expanded tool permissions, including read/write access and branch-detection capability.
  * Added guidance that automatically ensures the project .gitignore excludes skill working directories during initial setup (idempotent check; runs once per project).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->