### PR TITLE
[issues/4] Add hybrid text+JSON step tracking for scratchpad implementation plans

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -32,3 +32,15 @@
 **Two-tier design:** Foundation skills define standalone conventions (file formats, numbering, placement rules). Composite skills orchestrate workflows by referencing foundations by name — they never inline foundation definitions.
 
 **Non-invocable skills** (`user-invocable: false`) don't appear in the `/` menu but their descriptions load into Claude's context. Claude auto-consults them when the context matches (e.g., generating code references, deciding where to put files).
+
+## Step Tracking
+
+Implementation plan steps are embedded as a fenced JSON block inside the scratchpad's `## Implementation Plan` section. Each step has:
+
+- **`id`** — `S001`, `S002`, etc. (zero-padded 3-digit, mirrors Q001/A001)
+- **`status`** — `pending` | `in_progress` | `done` | `blocked`
+- **`done_when`** — concrete completion criteria (optional)
+- **`depends_on`** — array of step IDs that must be done first
+- **`files`** / **`tasks`** — what to touch and what to do
+
+Planning skills (`/start-issue`, `/tackle-pr-comment`) always write `"status": "pending"`. The `/tackle-scratchpad-block` skill manages status transitions during execution. See the `/scratchpad` skill for the full JSON schema.

--- a/skills/scratchpad/SKILL.md
+++ b/skills/scratchpad/SKILL.md
@@ -27,6 +27,54 @@ Files use `.txt` extension (not `.md`).
 
 The content is freeform — structure it for the purpose at hand (plan, analysis, PR description, etc.).
 
+## Step Tracking
+
+When a scratchpad contains an implementation plan, embed the steps inside a fenced JSON block within the `## Implementation Plan` section. The outer scratchpad remains freeform text; only the steps are structured.
+
+### JSON Schema
+
+```json
+{
+  "steps": [
+    {
+      "id": "S001",
+      "title": "Add parser module",
+      "status": "pending",
+      "done_when": "Parser exported and passing unit tests",
+      "depends_on": [],
+      "files": ["src/parser.ts", "src/index.ts"],
+      "tasks": [
+        "Create parseInput() function in src/parser.ts",
+        "Export from src/index.ts barrel file",
+        "Add unit tests in src/__tests__/parser.test.ts"
+      ]
+    },
+    {
+      "id": "S002",
+      "title": "Wire parser into request handler",
+      "status": "pending",
+      "depends_on": ["S001"],
+      "files": ["src/server.ts"],
+      "tasks": [
+        "Import parseInput from src/parser.ts",
+        "Call parseInput() in handleRequest()"
+      ]
+    }
+  ]
+}
+```
+
+### Field Reference
+
+- **`id`** — `S001`, `S002`, etc. Zero-padded 3-digit IDs mirroring the `/question` skill's `Q001`/`A001` pattern. Use `S001` as the short form in cross-references.
+- **`title`** — Short description of the step.
+- **`status`** — `pending` | `in_progress` | `done` | `blocked`. Planning skills always write `"pending"`. Only `/tackle-scratchpad-block` transitions status during execution.
+- **`done_when`** — Concrete completion criteria. Optional — omit for self-evident steps.
+- **`depends_on`** — Array of step IDs that must be `"done"` first. Empty array means no dependencies.
+- **`files`** — Array of file paths this step touches.
+- **`tasks`** — Array of concrete action items within the step.
+- **`addresses`** — (tackle-pr-comment only) Array of feedback item letters, e.g. `["A", "C"]`.
+
 ## Code References
 
 When referencing code in scratchpad content, format all file/line references per the `/code-ref` skill conventions. This makes references clickable when tools like RangeLink are installed.

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -65,22 +65,52 @@ Numbered steps that are:
 - **Ordered** — dependencies between steps are clear
 - **Testable** — each step should mention what tests to add/update
 
-Example format:
+Steps are embedded as a fenced JSON block (see `/scratchpad` Step Tracking section for full schema):
 
-### Step 1: <brief description>
+```json
+{
+  "steps": [
+    {
+      "id": "S001",
+      "title": "<brief description>",
+      "status": "pending",
+      "done_when": "<concrete criteria for this step>",
+      "depends_on": [],
+      "files": ["src/types/<filename>.ts", "src/types/index.ts"],
+      "tasks": [
+        "Add <TypeName> interface to src/types/<filename>.ts",
+        "Export from src/types/index.ts"
+      ]
+    },
+    {
+      "id": "S002",
+      "title": "<brief description>",
+      "status": "pending",
+      "done_when": "<concrete criteria for this step>",
+      "depends_on": ["S001"],
+      "files": ["src/<path>/<filename>.ts"],
+      "tasks": [
+        "Modify <functionName>() in src/<path>/<filename>.ts",
+        "Update return type, add new parameters"
+      ]
+    },
+    {
+      "id": "S003",
+      "title": "<brief description>",
+      "status": "pending",
+      "done_when": "All new functions have test coverage, tests pass",
+      "depends_on": ["S002"],
+      "files": ["src/<path>/__tests__/<filename>.test.ts"],
+      "tasks": [
+        "Add tests in src/<path>/__tests__/<filename>.test.ts",
+        "Cover happy path, edge cases, error conditions"
+      ]
+    }
+  ]
+}
+```
 
-- Add `<TypeName>` interface to `src/types/<filename>.ts`
-- Export from `src/types/index.ts`
-
-### Step 2: <brief description>
-
-- Modify `<functionName>()` in `src/<path>/<filename>.ts`
-- Update return type, add new parameters
-
-### Step 3: <brief description>
-
-- Add tests in `src/<path>/__tests__/<filename>.test.ts`
-- Cover happy path, edge cases, error conditions
+Note: Always set `"status": "pending"` when planning — `/tackle-scratchpad-block` manages status transitions during execution.
 
 ## Assumptions Made
 

--- a/skills/tackle-pr-comment/SKILL.md
+++ b/skills/tackle-pr-comment/SKILL.md
@@ -90,8 +90,8 @@ Where:
 
 ### Scratchpad Format
 
-**Naming convention**: Use letters (A, B, C) for feedback items, numbers (1, 2, 3) for implementation steps.
-This avoids confusion when referencing "Feedback B" vs "Step 2".
+**Naming convention**: Use letters (A, B, C) for feedback items in text headings, and `S001`, `S002` IDs for implementation steps in the JSON block.
+This avoids confusion when referencing "Feedback B" vs "S002".
 
 ```markdown
 # PR #{PR_NUMBER} Comment Response
@@ -122,20 +122,40 @@ Note: ACCEPT items flow to Implementation Plan steps. IGNORE items flow to the c
 
 ## Implementation Plan
 
-### Step 1: {description}
+```json
+{
+  "steps": [
+    {
+      "id": "S001",
+      "title": "{description}",
+      "status": "pending",
+      "done_when": "{concrete criteria}",
+      "depends_on": [],
+      "files": ["path/to/file.ts"],
+      "tasks": [
+        "What to change: {details}"
+      ],
+      "addresses": ["A", "C"]
+    },
+    {
+      "id": "S002",
+      "title": "{description}",
+      "status": "pending",
+      "done_when": "{concrete criteria}",
+      "depends_on": ["S001"],
+      "files": ["path/to/file.ts"],
+      "tasks": [
+        "What to change: {details}"
+      ],
+      "addresses": ["B"]
+    }
+  ]
+}
+```
 
-- Specific file: `path/to/file.ts`
-- What to change: {details}
-- Addresses: Feedback A, C
-
-### Step 2: {description}
-
-- Specific file: `path/to/file.ts`
-- What to change: {details}
-- Addresses: Feedback B
-
-Note: A single step can address multiple feedback items (as shown in Step 1 above).
+Note: A single step can address multiple feedback items (as shown in S001 above).
 Feedback items marked IGNORE in the Analysis section should not appear in any step.
+Always set `"status": "pending"` — `/tackle-scratchpad-block` manages status transitions during execution.
 
 ## Recommendations
 

--- a/skills/tackle-scratchpad-block/SKILL.md
+++ b/skills/tackle-scratchpad-block/SKILL.md
@@ -19,6 +19,15 @@ Read the lines specified by the code reference to get the step(s) to execute.
 
 **If the reference doesn't resolve** (file not found, lines don't exist, or content isn't actionable steps): STOP immediately and report the issue. Do not attempt to guess, search for alternatives, or infer intent.
 
+### Check Step Status
+
+After reading the step, parse the `"status"` field from the JSON:
+
+- **`"done"`** → Warn the user: "This step is already done. Re-execute anyway?" Wait for confirmation.
+- **`"blocked"`** → Read the `"depends_on"` array and check if the blocking steps have `"status": "done"` in the scratchpad's JSON block. If they do, proceed (the block is resolved). If not, warn: "This step depends on S00N which is not yet done." Wait for confirmation.
+- **`"in_progress"`** → Warn the user: "This step is in_progress, possibly from an interrupted run. Continue?" Wait for confirmation.
+- **`"pending"`** → proceed normally.
+
 ## Step 2: Understand the Context
 
 Read the full scratchpad to understand:
@@ -37,9 +46,19 @@ Before executing, assess if the steps are clear enough:
 
 **If clear**: Proceed to Step 4.
 
-## Step 4: Execute the Steps
+## Step 4: Mark In-Progress and Execute
 
-Perform the implementation work as specified in the selected lines:
+Before executing, update the step's status in the scratchpad's JSON block:
+
+```json
+"id": "S002",
+"title": "Implement handler",
+"status": "in_progress",
+```
+
+Use the Edit tool to replace `"status": "pending"` (or `"status": "blocked"`) with `"status": "in_progress"`. Include the `"id"` and `"title"` fields in the old_string for Edit uniqueness.
+
+Then perform the implementation work as specified in the selected lines:
 
 - Make code changes
 - Add/update tests as needed
@@ -51,7 +70,19 @@ Run the project's test suite after making changes.
 
 **Exception**: Skip tests only if the scratchpad block explicitly says not to run them for this step.
 
-## Step 5: Create Commit Message File
+## Step 5: Mark Done and Create Commit Message File
+
+After successful execution and passing tests, update the step's status in the scratchpad's JSON block:
+
+```json
+"id": "S002",
+"title": "Implement handler",
+"status": "done",
+```
+
+Use the Edit tool to replace `"status": "in_progress"` with `"status": "done"`. Include the `"id"` and `"title"` fields in the old_string for Edit uniqueness.
+
+**If tests fail or execution is incomplete**, leave the step as `"in_progress"` — do NOT mark it `"done"`.
 
 **IMPORTANT**: Always create a NEW commit message file for this block. Never reuse commit message files from previous steps.
 


### PR DESCRIPTION
## Summary

Adds structured step tracking to scratchpad implementation plans by embedding steps as a JSON block inside the text document. Steps have machine-parseable fields for status, dependencies, completion criteria, files, and granular tasks — while the outer scratchpad (Context, Analysis, Recommendations) stays human-readable text.

## Changes

- Defined JSON step schema in the scratchpad skill with full field reference (id, status, done_when, depends_on, files, tasks, addresses)
- Updated start-issue and tackle-pr-comment templates to generate JSON step blocks instead of text headings
- Updated tackle-scratchpad-block to read/write JSON status fields during execution (pending → in_progress → done)
- Updated skills/README.md step tracking summary to describe the JSON format

## Test Plan

- [ ] All skills load correctly in Claude Code (no frontmatter/syntax errors)
- [ ] `/start-issue` generates scratchpads with JSON step blocks
- [ ] `/tackle-pr-comment` generates scratchpads with JSON step blocks including `addresses` field
- [ ] `/tackle-scratchpad-block` correctly transitions status fields in JSON using Edit tool
- [ ] Step IDs (S001, S002) are consistent across all skill templates

## Related

- Closes #4
