### PR TITLE
[docs] Add unreleased markers guidance to `finish-issue` and `start-issue` skills

### DIFF
--- a/skills/finish-issue/SKILL.md
+++ b/skills/finish-issue/SKILL.md
@@ -53,6 +53,13 @@ Check if documentation updates are needed. Common touchpoints:
 - New feature → Document appropriately
 - Internal changes → Usually no update
 
+**Unreleased markers** (if project uses trunk-based documentation):
+
+- New section headers → Add `<sup>Unreleased</sup>` marker
+- New command/setting table rows → Add `<sup>Unreleased</sup>` marker
+- If no top-of-README banner exists → Add one explaining the convention
+- Check project's CLAUDE.md or release docs for the exact convention
+
 **Project-specific integration points**:
 
 - Verify commands/keybindings/settings/menus already added during implementation

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -129,6 +129,7 @@ Check the project's documentation and discoverability conventions. Common touchp
 - [ ] CHANGELOG entry (under appropriate version section)
 - [ ] README update (if new command, setting, or feature)
 - [ ] Any project-specific integration points (entry points, config, menus, keybindings)
+- [ ] Unreleased markers on new README content (if project uses trunk-based documentation)
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
Trunk-based projects document features in README before release, but without markers visitors can't tell what's released vs upcoming. The documentation review steps in `/finish-issue` and `/start-issue` didn't flag this, so it was easy to forget.

Benefits:
- `/finish-issue` Step 3 now prompts for unreleased markers on new README content
- `/start-issue` planning checklist flags the need early, before implementation starts
- Guidance is conditional ("if project uses trunk-based documentation") so it doesn't apply universally