### PR TITLE
[chore] Version CHANGELOG ## Unreleased → ## 2026.02.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
-## Unreleased
+## 2026.02.24
 
 ### Added
 


### PR DESCRIPTION
PR #24 was merged without replacing the Unreleased heading with a real CalVer version. This retroactively versions the entries from that PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Changelog now uses CalVer versioning format for clearer release tracking.
  * Added versioning section in README linking to detailed changelog.

* **Chores**
  * Enhanced CI with non-blocking checks to ensure changelog updates with pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->