### PR TITLE
[issues/94] Fix tar cache restore failures in bats-action CI step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
       - run: bats tests/


### PR DESCRIPTION
## Summary

Disables the 4 unused bats helper library installations (support, assert, detik, file) in the test workflow. The `bats-action` installs these by default, each with its own `actions/cache` entry. Our tests only use plain `bats`, so these cache entries were never properly populated — causing 4 "Failed to restore: tar failed with exit code 2" warnings on every CI run.

## Changes

- Added `with:` block to `bats-action` step in test workflow, setting `support-install`, `assert-install`, `detik-install`, and `file-install` to `false`

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test workflow configuration to refine automated testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->