### PR TITLE
[issues/86] Document multi-candidate step selection in start-issue output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.03.16.1
+
+### Changed
+
+- Added multi-candidate step selection note to `/start-issue` output — users now see how to specify a step ID (`#S002`) when multiple steps have no dependencies ([issues/86](https://github.com/couimet/my-claude-skills/issues/86))
+
 ## 2026.03.16
 
 ### Changed

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -178,6 +178,8 @@ Print the branch name and paths of any created scratchpad/questions files, follo
 Next: use `/tackle-scratchpad-block` to execute steps one at a time.
 Example: /tackle-scratchpad-block <path-to-scratchpad>
 (auto-selects first pending, unblocked step)
+If multiple pending, unblocked steps exist, specify which one:
+  /tackle-scratchpad-block <path-to-scratchpad>#S002
 ```
 
 Replace `<path-to-scratchpad>` with the actual path of the scratchpad file created in Step 4.


### PR DESCRIPTION
## Summary

When `/tackle-scratchpad-block` finds multiple pending, unblocked steps it pauses and asks the user to pick one. But `/start-issue`'s output implied auto-selection would just work. This adds a note to the output template showing users how to specify a step ID when multiple candidates exist.

## Changes

- Added a line to `/start-issue`'s Step 6 output template showing the `#S002` syntax for targeting a specific step when multiple are unblocked

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how to select a specific pending step when multiple unblocked steps exist.
  * Added usage guidance for appending a step ID selector (e.g., `#S002`) to execution commands to target a specific step.
* **Chores**
  * Added a new CALVER release note entry documenting the multi-candidate selection guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->