### PR TITLE
[issues/45] Better promote the case study for `demo/issues-10`

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ The [`demo/real-life/issues-10/`](demo/real-life/issues-10/) folder contains eve
 
 The most recent posts are at the top.
 
+- [From Vide Coding to Supercharged Vibe Guiding](https://dev.to/couimet/from-vide-coding-to-supercharged-vibe-guiding-6nm) - DEV Community
 - [Claude skills: issues-10](https://ouimet.info/follow-alongs/my-claude-skills-issues-10.html) — a full follow-along showing how these skills turned a blank issue into a shipped PR, with every artifact visible
 
 ## Why I Built These


### PR DESCRIPTION
## Summary

The follow-along article showing how these skills compose into a full issue lifecycle was published but invisible from the README. This PR adds a hero callout, a shields.io badge, and a "Featured In" section so readers discover it within the first screenful.

## Changes

- Added a hero blockquote after the intro paragraphs linking to the follow-along article
- Added a "Follow-along" shields.io badge next to the existing CodeRabbit badge
- Added a "Featured In" section (after "See It In Action") listing the follow-along and the DEV Community article, following the same pattern as rangeLink's VS Code extension README

## Cross-Repo Issues Created

- https://github.com/couimet/rangeLink/issues/474 — add reciprocal "Featured In" entry to the rangeLink VS Code extension README
- https://github.com/couimet/couimet.github.io/issues/12 — improve the follow-along article title (currently reads like a filename)

## Related

Closes https://github.com/couimet/my-claude-skills/issues/45


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a prominent callout encouraging visitors to explore featured projects and skills in action with direct resource links.
  * Introduced a new "Featured In" section showcasing recent posts and articles, with the latest content appearing first for easy discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->