### PR TITLE
[issues/119] Make `/question`, `/scratchpad`, `/commit-msg` self-contained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.04.20
+
+### Fixed
+
+- `/question`, `/scratchpad`, and `/commit-msg` now reliably produce unique `NNNN-` prefixes when used outside an `issues/*` branch; the skills inline branch detection and the `auto-number.sh` call instead of delegating to `/issue-context`, closing a gap where the delegation chain was sometimes shortcut and every flat-root file ended up with the same `0001-` prefix ([issues/119](https://github.com/couimet/my-claude-skills/issues/119))
+
 ## 2026.03.29
 
 ### Added

--- a/skills/README.md
+++ b/skills/README.md
@@ -15,12 +15,12 @@
 
 | Skill | Purpose |
 | --- | --- |
-| `auto-number` | Reusable file sequence numbering with prefix (`NNNN-name`) and suffix (`name-NNNN`) modes. Auto-consulted by `/issue-context` and available for direct use by other skills. |
+| `auto-number` | Reusable file sequence numbering with prefix (`NNNN-name`) and suffix (`name-NNNN`) modes. Called directly by `/question`, `/scratchpad`, `/commit-msg`, and `/issue-context`. |
 | `code-ref` | Defines permalink format for code references (`path/to/file.ts#L10-L20`). Claude auto-consults when generating file/line references. |
-| `ensure-gitignore` | Checks that `.gitignore` contains the Claude working directory sentinel and appends it if missing. One Bash call — no file contents loaded into context. Auto-consulted by `/issue-context`. |
+| `ensure-gitignore` | Checks that `.gitignore` contains the Claude working directory sentinel and appends it if missing. One Bash call — no file contents loaded into context. Called directly by `/question`, `/scratchpad`, `/commit-msg`, and `/issue-context`. |
 | `file-placement` | Decision tree for where to put different file types. Claude auto-consults when deciding output locations. |
 | `label-discovery` | Fetches GitHub labels, classifies them as defaults vs structured, and prompts the user for selection. Auto-consulted by `/create-github-issue`. |
-| `issue-context` | Detects issue context from git branch name, determines subdirectory organization and `NNNN` file numbering. Claude auto-consults when foundation skills need directory placement. |
+| `issue-context` | Detects issue context from git branch name, documents the `NNNN` organization convention, and provides the ID-extraction rules that `/breadcrumb`, `/cleanup-issue`, and `/start-issue` consult when reasoning about issue-scoped paths. |
 | `scratchpad-ref-format` | Defines the 4 invocation forms for referencing scratchpad steps (`#S`, `#L`, space-separated, bare-path auto-select). Auto-consulted by `/tackle-scratchpad-block` when parsing its argument. |
 
 ## Composite Skills (higher-level workflows)

--- a/skills/commit-msg/SKILL.md
+++ b/skills/commit-msg/SKILL.md
@@ -18,7 +18,7 @@ Focus on **WHY**, not **WHAT**. The git diff already shows what changed — the 
 
 ## Step 1: Determine Target Directory and Filename
 
-Run both commands as parallel tool calls — they are independent:
+Run these two commands as parallel tool calls — they are independent. The `auto-number.sh` invocation in the "Sequence number" section below is NOT parallel with these; it must run afterward because it takes the branch-derived target directory as input.
 
 ```bash
 git branch --show-current
@@ -30,7 +30,16 @@ skills/ensure-gitignore/ensure-gitignore.sh
 
 ### Target directory
 
-If the branch starts with `issues/`, extract the issue ID (characters after `issues/` up to the first `-` or `_`, only if those characters are purely numeric; otherwise use the full string after `issues/`):
+If the branch starts with `issues/`, extract the issue ID: take the characters after `issues/` up to the first `-` or `_`, but only if those characters are purely numeric. Otherwise the ID is the full string after `issues/`.
+
+Examples:
+
+- `issues/332` → ID is `332`
+- `issues/332-add-parser` → ID is `332`
+- `issues/rfc-auth` → ID is `rfc-auth` (not purely numeric before `-`)
+- `main`, `side-quest/foo`, `feature/bar` → no issue context
+
+Target directory:
 
 - **On an issue branch:** `.claude-work/issues/<ID>/commit-msgs/`
 - **Otherwise:** `.claude-work/commit-msgs/`

--- a/skills/commit-msg/SKILL.md
+++ b/skills/commit-msg/SKILL.md
@@ -16,18 +16,43 @@ Create a commit message file in `.claude-work/`. The user reviews and runs `git 
 
 Focus on **WHY**, not **WHAT**. The git diff already shows what changed — the commit message explains the motivation, the problem being solved, and the benefits. Message depth should scale with the cognitive load of the change — not every commit needs a body or Benefits section.
 
-## Directory and Numbering
+## Step 1: Determine Target Directory and Filename
 
-Follow the `/issue-context` skill to determine the target directory and `NNNN` file sequence number. The type subdirectory is `commit-msgs/`.
+Run both commands as parallel tool calls — they are independent:
 
-- Issue-scoped: `.claude-work/issues/<ID>/commit-msgs/NNNN-description.txt`
-- Flat (no issue context): `.claude-work/commit-msgs/NNNN-description.txt`
+```bash
+git branch --show-current
+```
 
-## Naming Pattern
+```bash
+skills/ensure-gitignore/ensure-gitignore.sh
+```
 
-The filename is `NNNN-description.txt` where `NNNN` comes from `/issue-context` auto-numbering.
+### Target directory
 
-Derive the description slug from $ARGUMENTS (lowercase, hyphens, no special chars).
+If the branch starts with `issues/`, extract the issue ID (characters after `issues/` up to the first `-` or `_`, only if those characters are purely numeric; otherwise use the full string after `issues/`):
+
+- **On an issue branch:** `.claude-work/issues/<ID>/commit-msgs/`
+- **Otherwise:** `.claude-work/commit-msgs/`
+
+### Sequence number
+
+Run:
+
+```bash
+skills/auto-number/auto-number.sh <target-directory> --glob "*.txt" --width 4 --mkdir
+```
+
+Use the stdout (e.g., `0001`) as the `NNNN` value. The `--mkdir` flag creates the directory if it does not exist, so the script works on a fresh checkout.
+
+### Filename
+
+`<target-directory>/NNNN-<slug>.txt` where `<slug>` is derived from $ARGUMENTS (lowercase, replace spaces and special characters with hyphens, collapse consecutive hyphens, trim leading/trailing hyphens).
+
+Examples:
+
+- `.claude-work/issues/332/commit-msgs/0001-add-parser.txt`
+- `.claude-work/commit-msgs/0012-refactor-api.txt`
 
 ## Complexity Assessment
 

--- a/skills/question/SKILL.md
+++ b/skills/question/SKILL.md
@@ -18,7 +18,7 @@ Questions are NEVER printed in terminal output. They go to a file that the user 
 
 ## Step 1: Determine Target Directory and Filename
 
-Run both commands as parallel tool calls — they are independent:
+Run these two commands as parallel tool calls — they are independent. The `auto-number.sh` invocation in the "Sequence number" section below is NOT parallel with these; it must run afterward because it takes the branch-derived target directory as input.
 
 ```bash
 git branch --show-current
@@ -30,7 +30,16 @@ skills/ensure-gitignore/ensure-gitignore.sh
 
 ### Target directory
 
-If the branch starts with `issues/`, extract the issue ID (characters after `issues/` up to the first `-` or `_`, only if those characters are purely numeric; otherwise use the full string after `issues/`):
+If the branch starts with `issues/`, extract the issue ID: take the characters after `issues/` up to the first `-` or `_`, but only if those characters are purely numeric. Otherwise the ID is the full string after `issues/`.
+
+Examples:
+
+- `issues/332` → ID is `332`
+- `issues/332-add-parser` → ID is `332`
+- `issues/rfc-auth` → ID is `rfc-auth` (not purely numeric before `-`)
+- `main`, `side-quest/foo`, `feature/bar` → no issue context
+
+Target directory:
 
 - **On an issue branch:** `.claude-work/issues/<ID>/questions/`
 - **Otherwise:** `.claude-work/questions/`

--- a/skills/question/SKILL.md
+++ b/skills/question/SKILL.md
@@ -16,18 +16,43 @@ Create a questions file in `.claude-work/` for gathering user input.
 
 Questions are NEVER printed in terminal output. They go to a file that the user edits directly. The file is the single source of truth for both questions and answers.
 
-## Directory and Numbering
+## Step 1: Determine Target Directory and Filename
 
-Follow the `/issue-context` skill to determine the target directory and `NNNN` file sequence number. The type subdirectory is `questions/`.
+Run both commands as parallel tool calls — they are independent:
 
-- Issue-scoped: `.claude-work/issues/<ID>/questions/NNNN-description.txt`
-- Flat (no issue context): `.claude-work/questions/NNNN-description.txt`
+```bash
+git branch --show-current
+```
 
-## Naming Pattern
+```bash
+skills/ensure-gitignore/ensure-gitignore.sh
+```
 
-The filename is `NNNN-description.txt` where `NNNN` comes from `/issue-context` auto-numbering.
+### Target directory
 
-Derive the description slug from $ARGUMENTS (lowercase, hyphens, no special chars).
+If the branch starts with `issues/`, extract the issue ID (characters after `issues/` up to the first `-` or `_`, only if those characters are purely numeric; otherwise use the full string after `issues/`):
+
+- **On an issue branch:** `.claude-work/issues/<ID>/questions/`
+- **Otherwise:** `.claude-work/questions/`
+
+### Sequence number
+
+Run:
+
+```bash
+skills/auto-number/auto-number.sh <target-directory> --glob "*.txt" --width 4 --mkdir
+```
+
+Use the stdout (e.g., `0001`) as the `NNNN` value. The `--mkdir` flag creates the directory if it does not exist, so the script works on a fresh checkout.
+
+### Filename
+
+`<target-directory>/NNNN-<slug>.txt` where `<slug>` is derived from $ARGUMENTS (lowercase, replace spaces and special characters with hyphens, collapse consecutive hyphens, trim leading/trailing hyphens).
+
+Examples:
+
+- `.claude-work/issues/332/questions/0001-api-design.txt`
+- `.claude-work/questions/0003-architecture-options.txt`
 
 ## File Format
 

--- a/skills/scratchpad/SKILL.md
+++ b/skills/scratchpad/SKILL.md
@@ -14,7 +14,7 @@ Create or update a working document in `.claude-work/`.
 
 ## Step 1: Determine Target Directory and Filename
 
-Run both commands as parallel tool calls — they are independent:
+Run these two commands as parallel tool calls — they are independent. The `auto-number.sh` invocation in the "Sequence number" section below is NOT parallel with these; it must run afterward because it takes the branch-derived target directory as input.
 
 ```bash
 git branch --show-current
@@ -26,7 +26,16 @@ skills/ensure-gitignore/ensure-gitignore.sh
 
 ### Target directory
 
-If the branch starts with `issues/`, extract the issue ID (characters after `issues/` up to the first `-` or `_`, only if those characters are purely numeric; otherwise use the full string after `issues/`):
+If the branch starts with `issues/`, extract the issue ID: take the characters after `issues/` up to the first `-` or `_`, but only if those characters are purely numeric. Otherwise the ID is the full string after `issues/`.
+
+Examples:
+
+- `issues/332` → ID is `332`
+- `issues/332-add-parser` → ID is `332`
+- `issues/rfc-auth` → ID is `rfc-auth` (not purely numeric before `-`)
+- `main`, `side-quest/foo`, `feature/bar` → no issue context
+
+Target directory:
 
 - **On an issue branch:** `.claude-work/issues/<ID>/scratchpads/`
 - **Otherwise:** `.claude-work/scratchpads/`

--- a/skills/scratchpad/SKILL.md
+++ b/skills/scratchpad/SKILL.md
@@ -12,18 +12,43 @@ Create or update a working document in `.claude-work/`.
 
 **Input:** $ARGUMENTS (a short description for the filename)
 
-## Directory and Numbering
+## Step 1: Determine Target Directory and Filename
 
-Follow the `/issue-context` skill to determine the target directory and `NNNN` file sequence number. The type subdirectory is `scratchpads/`.
+Run both commands as parallel tool calls — they are independent:
 
-- Issue-scoped: `.claude-work/issues/<ID>/scratchpads/NNNN-description.txt`
-- Flat (no issue context): `.claude-work/scratchpads/NNNN-description.txt`
+```bash
+git branch --show-current
+```
 
-## Naming Pattern
+```bash
+skills/ensure-gitignore/ensure-gitignore.sh
+```
 
-The filename is `NNNN-description.txt` where `NNNN` comes from `/issue-context` auto-numbering.
+### Target directory
 
-Derive the description slug from $ARGUMENTS (lowercase, hyphens, no special chars).
+If the branch starts with `issues/`, extract the issue ID (characters after `issues/` up to the first `-` or `_`, only if those characters are purely numeric; otherwise use the full string after `issues/`):
+
+- **On an issue branch:** `.claude-work/issues/<ID>/scratchpads/`
+- **Otherwise:** `.claude-work/scratchpads/`
+
+### Sequence number
+
+Run:
+
+```bash
+skills/auto-number/auto-number.sh <target-directory> --glob "*.txt" --width 4 --mkdir
+```
+
+Use the stdout (e.g., `0001`) as the `NNNN` value. The `--mkdir` flag creates the directory if it does not exist, so the script works on a fresh checkout.
+
+### Filename
+
+`<target-directory>/NNNN-<slug>.txt` where `<slug>` is derived from $ARGUMENTS (lowercase, replace spaces and special characters with hyphens, collapse consecutive hyphens, trim leading/trailing hyphens).
+
+Examples:
+
+- `.claude-work/issues/332/scratchpads/0001-implementation-plan.txt`
+- `.claude-work/scratchpads/0042-refactoring-analysis.txt`
 
 ## File Format
 

--- a/tests/commit-msg-self-contained.bats
+++ b/tests/commit-msg-self-contained.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+SKILL="$PROJECT_ROOT/skills/commit-msg/SKILL.md"
+
+# =============================================================
+# Self-contained: no foundation skill cross-references
+# =============================================================
+
+@test "commit-msg skill: does not cross-reference /issue-context" {
+  ! grep -q "/issue-context" "$SKILL"
+}
+
+# =============================================================
+# Inlined branch detection and auto-number invocation
+# =============================================================
+
+@test "commit-msg skill: inlines git branch --show-current" {
+  grep -q "git branch --show-current" "$SKILL"
+}
+
+@test "commit-msg skill: inlines auto-number.sh invocation" {
+  grep -q "skills/auto-number/auto-number.sh" "$SKILL"
+}
+
+@test "commit-msg skill: auto-number call uses --mkdir flag for fresh checkouts" {
+  grep "auto-number.sh" "$SKILL" | grep -q -- "--mkdir"
+}
+
+@test "commit-msg skill: auto-number call filters to *.txt files" {
+  grep "auto-number.sh" "$SKILL" | grep -q -- '--glob "\*\.txt"'
+}
+
+# =============================================================
+# Both directory contexts documented
+# =============================================================
+
+@test "commit-msg skill: documents issue-scoped directory path" {
+  grep -q '\.claude-work/issues/.*commit-msgs/' "$SKILL"
+}
+
+@test "commit-msg skill: documents flat-root directory path" {
+  grep -q '\.claude-work/commit-msgs/' "$SKILL"
+}

--- a/tests/commit-msg-self-contained.bats
+++ b/tests/commit-msg-self-contained.bats
@@ -4,6 +4,14 @@ load test_helper
 
 SKILL="$PROJECT_ROOT/skills/commit-msg/SKILL.md"
 
+setup() {
+  TEST_TEMP_DIR="$(mktemp -d)"
+  [ -f "$SKILL" ] || {
+    echo "SKILL file not found: $SKILL" >&2
+    return 1
+  }
+}
+
 # =============================================================
 # Self-contained: no foundation skill cross-references
 # =============================================================

--- a/tests/question-self-contained.bats
+++ b/tests/question-self-contained.bats
@@ -4,6 +4,14 @@ load test_helper
 
 SKILL="$PROJECT_ROOT/skills/question/SKILL.md"
 
+setup() {
+  TEST_TEMP_DIR="$(mktemp -d)"
+  [ -f "$SKILL" ] || {
+    echo "SKILL file not found: $SKILL" >&2
+    return 1
+  }
+}
+
 # =============================================================
 # Self-contained: no foundation skill cross-references
 # =============================================================

--- a/tests/question-self-contained.bats
+++ b/tests/question-self-contained.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+SKILL="$PROJECT_ROOT/skills/question/SKILL.md"
+
+# =============================================================
+# Self-contained: no foundation skill cross-references
+# =============================================================
+
+@test "question skill: does not cross-reference /issue-context" {
+  ! grep -q "/issue-context" "$SKILL"
+}
+
+# =============================================================
+# Inlined branch detection and auto-number invocation
+# =============================================================
+
+@test "question skill: inlines git branch --show-current" {
+  grep -q "git branch --show-current" "$SKILL"
+}
+
+@test "question skill: inlines auto-number.sh invocation" {
+  grep -q "skills/auto-number/auto-number.sh" "$SKILL"
+}
+
+@test "question skill: auto-number call uses --mkdir flag for fresh checkouts" {
+  grep "auto-number.sh" "$SKILL" | grep -q -- "--mkdir"
+}
+
+@test "question skill: auto-number call filters to *.txt files" {
+  grep "auto-number.sh" "$SKILL" | grep -q -- '--glob "\*\.txt"'
+}
+
+# =============================================================
+# Both directory contexts documented
+# =============================================================
+
+@test "question skill: documents issue-scoped directory path" {
+  grep -q '\.claude-work/issues/.*questions/' "$SKILL"
+}
+
+@test "question skill: documents flat-root directory path" {
+  grep -q '\.claude-work/questions/' "$SKILL"
+}

--- a/tests/scratchpad-self-contained.bats
+++ b/tests/scratchpad-self-contained.bats
@@ -4,6 +4,14 @@ load test_helper
 
 SKILL="$PROJECT_ROOT/skills/scratchpad/SKILL.md"
 
+setup() {
+  TEST_TEMP_DIR="$(mktemp -d)"
+  [ -f "$SKILL" ] || {
+    echo "SKILL file not found: $SKILL" >&2
+    return 1
+  }
+}
+
 # =============================================================
 # Self-contained: no foundation skill cross-references
 # =============================================================

--- a/tests/scratchpad-self-contained.bats
+++ b/tests/scratchpad-self-contained.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+SKILL="$PROJECT_ROOT/skills/scratchpad/SKILL.md"
+
+# =============================================================
+# Self-contained: no foundation skill cross-references
+# =============================================================
+
+@test "scratchpad skill: does not cross-reference /issue-context" {
+  ! grep -q "/issue-context" "$SKILL"
+}
+
+# =============================================================
+# Inlined branch detection and auto-number invocation
+# =============================================================
+
+@test "scratchpad skill: inlines git branch --show-current" {
+  grep -q "git branch --show-current" "$SKILL"
+}
+
+@test "scratchpad skill: inlines auto-number.sh invocation" {
+  grep -q "skills/auto-number/auto-number.sh" "$SKILL"
+}
+
+@test "scratchpad skill: auto-number call uses --mkdir flag for fresh checkouts" {
+  grep "auto-number.sh" "$SKILL" | grep -q -- "--mkdir"
+}
+
+@test "scratchpad skill: auto-number call filters to *.txt files" {
+  grep "auto-number.sh" "$SKILL" | grep -q -- '--glob "\*\.txt"'
+}
+
+# =============================================================
+# Both directory contexts documented
+# =============================================================
+
+@test "scratchpad skill: documents issue-scoped directory path" {
+  grep -q '\.claude-work/issues/.*scratchpads/' "$SKILL"
+}
+
+@test "scratchpad skill: documents flat-root directory path" {
+  grep -q '\.claude-work/scratchpads/' "$SKILL"
+}


### PR DESCRIPTION
## Summary

Fixes a reliability gap where `/question` (and its siblings `/scratchpad` and `/commit-msg`) produced multiple files with the same `0001-` prefix when used outside an `issues/*` branch. The three skills now inline branch detection and the `auto-number.sh` invocation directly in their SKILL.md body instead of delegating to `/issue-context`, removing the step Claude was sometimes skipping.

## Changes

- Replaced the "Directory and Numbering" + "Naming Pattern" sections in `/question`, `/scratchpad`, and `/commit-msg` with a self-contained Step 1 that runs `git branch --show-current`, extracts the issue ID (with the same split-on-first-`-`-or-`_`-if-purely-numeric rule `/issue-context` documents), and invokes `skills/auto-number/auto-number.sh <dir> --glob "*.txt" --width 4 --mkdir` to get `NNNN`
- Updated `skills/README.md` to reflect that `auto-number` and `ensure-gitignore` are now called directly by these three skills (not just by `/issue-context`), and rescoped the `issue-context` description to the skills that still consult it (`/breadcrumb`, `/cleanup-issue`, `/start-issue`)
- Added three new bats test files (`tests/question-self-contained.bats`, `tests/scratchpad-self-contained.bats`, `tests/commit-msg-self-contained.bats`) that assert each skill has no `/issue-context` cross-reference and does inline both `git branch --show-current` and `auto-number.sh` with the correct `--mkdir` and `--glob "*.txt"` flags
- Added a CHANGELOG entry under `## 2026.04.20` → `### Fixed`

## Test Plan

- [x] `make lint` passes (markdownlint-cli2 reports 0 errors across all changed markdown files)
- [x] `make test` passes (146 tests, including 21 new self-contained assertions across the three skills)
- [x] Manual verification: running `skills/auto-number/auto-number.sh .claude-work/questions --glob "*.txt" --width 4 --mkdir` on an empty directory returns `0001`, and on a directory with one matching file returns `0002` — confirming the script already behaved correctly and the bug was purely in the delegation chain

## Documentation

- [x] CHANGELOG: Fixed entry added under new `## 2026.04.20` heading linking to https://github.com/couimet/my-claude-skills/issues/119
- [x] README: `skills/README.md` updated to reflect the new call paths for `auto-number`, `ensure-gitignore`, and `issue-context`; root `README.md` had no references to the old delegation chain and needed no changes

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/119
- Related: https://github.com/couimet/my-claude-skills/issues/117 established the self-contained pattern with `/note` (new skill with zero foundation-skill cross-references); this issue applies the same remedy retroactively to three existing skills
- Adjacent: https://github.com/couimet/my-claude-skills/issues/120 tracks the broader DRY-vs-copy-paste audit; this PR intentionally stays narrow to the reported bug and feeds three more data points into that audit rather than preempting its conclusions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unique prefix generation for `/question`, `/scratchpad`, and `/commit-msg` when executed outside issue branches.

* **Documentation**
  * Updated skill documentation to clarify direct invocation workflows and branch-based directory logic for question, scratchpad, and commit-message operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->