### PR TITLE
[side-quest/step1-absolute-paths] Use absolute `~/.claude/skills/...`paths in SKILL.md script invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.04.22
+
+### Fixed
+
+- `/scratchpad`, `/question`, `/commit-msg`, and `/create-github-issue` now invoke their foundation scripts via absolute `~/.claude/skills/...` paths instead of relative `skills/...` paths — the relative form only resolved when Claude was running from inside the `my-claude-skills` repo, so these skills broke with `Exit 127: no such file or directory` in every other project. Contract docs (`/issue-context`, `/ensure-gitignore`, `/auto-number`, `/file-placement`) updated to the same pattern for consistency
+
 ## 2026.04.20.1
 
 ### Added

--- a/skills/auto-number/SKILL.md
+++ b/skills/auto-number/SKILL.md
@@ -3,7 +3,7 @@ name: auto-number
 version: 2026.04.20.1@a34fc99
 user-invocable: false
 description: Reusable file sequence numbering with prefix (NNNN-name) and suffix (name-NNNN) modes. Returns the next available zero-padded sequence number for a given directory.
-allowed-tools: Bash(*/~/.claude/skills/auto-number/auto-number.sh *)
+allowed-tools: Bash(*/skills/auto-number/auto-number.sh *)
 ---
 
 # Auto-Number

--- a/skills/auto-number/SKILL.md
+++ b/skills/auto-number/SKILL.md
@@ -3,7 +3,7 @@ name: auto-number
 version: 2026.04.20.1@a34fc99
 user-invocable: false
 description: Reusable file sequence numbering with prefix (NNNN-name) and suffix (name-NNNN) modes. Returns the next available zero-padded sequence number for a given directory.
-allowed-tools: Bash(*/skills/auto-number/auto-number.sh *)
+allowed-tools: Bash(*/~/.claude/skills/auto-number/auto-number.sh *)
 ---
 
 # Auto-Number
@@ -13,7 +13,7 @@ Returns the next available sequence number for files in a directory. Run the scr
 ## Usage
 
 ```bash
-skills/auto-number/auto-number.sh <directory> [--mode prefix|suffix] [--glob PATTERN] [--width N]
+~/.claude/skills/auto-number/auto-number.sh <directory> [--mode prefix|suffix] [--glob PATTERN] [--width N]
 ```
 
 **Arguments:**
@@ -30,13 +30,13 @@ skills/auto-number/auto-number.sh <directory> [--mode prefix|suffix] [--glob PAT
 ```bash
 # Next prefix number in .claude-work/issues/5/commit-msgs/ (default mode, default width)
 # NOTE: do NOT pass "prefix" as a positional argument — just omit --mode
-skills/auto-number/auto-number.sh .claude-work/issues/5/commit-msgs
+~/.claude/skills/auto-number/auto-number.sh .claude-work/issues/5/commit-msgs
 
 # Next suffix number, only counting .json files
-skills/auto-number/auto-number.sh some/dir --mode suffix --glob "*.json"
+~/.claude/skills/auto-number/auto-number.sh some/dir --mode suffix --glob "*.json"
 
 # Next number with 6-digit padding
-skills/auto-number/auto-number.sh some/dir --width 6
+~/.claude/skills/auto-number/auto-number.sh some/dir --width 6
 ```
 
 ## Common Mistakes
@@ -45,19 +45,19 @@ skills/auto-number/auto-number.sh some/dir --width 6
 
 ```bash
 # This will fail with: E002 error: unexpected argument 'prefix'
-skills/auto-number/auto-number.sh .claude-work/issues/5/scratchpads prefix
+~/.claude/skills/auto-number/auto-number.sh .claude-work/issues/5/scratchpads prefix
 ```
 
 **RIGHT** — omit `--mode` entirely for prefix (it is the default):
 
 ```bash
-skills/auto-number/auto-number.sh .claude-work/issues/5/scratchpads
+~/.claude/skills/auto-number/auto-number.sh .claude-work/issues/5/scratchpads
 ```
 
 **RIGHT** — use `--mode` flag when explicitly specifying a mode:
 
 ```bash
-skills/auto-number/auto-number.sh .claude-work/issues/5/scratchpads --mode suffix
+~/.claude/skills/auto-number/auto-number.sh .claude-work/issues/5/scratchpads --mode suffix
 ```
 
 ## Behavior

--- a/skills/commit-msg/SKILL.md
+++ b/skills/commit-msg/SKILL.md
@@ -25,11 +25,11 @@ Focus on **WHY**, not **WHAT**. The git diff already shows what changed — the 
 Run these two commands as parallel tool calls — they are independent.
 
 ```bash
-skills/issue-context/target-path.sh --type commit-msgs --description "$ARGUMENTS"
+~/.claude/skills/issue-context/target-path.sh --type commit-msgs --description "$ARGUMENTS"
 ```
 
 ```bash
-skills/ensure-gitignore/ensure-gitignore.sh
+~/.claude/skills/ensure-gitignore/ensure-gitignore.sh
 ```
 
 Use the stdout of the first command as the full file path. The script handles branch detection, issue-ID extraction, directory creation, auto-numbering, and slug normalization in one call. On an `issues/<ID>` branch the output is `.claude-work/issues/<ID>/commit-msgs/NNNN-<slug>.txt`; otherwise `.claude-work/commit-msgs/NNNN-<slug>.txt`.

--- a/skills/create-github-issue/SKILL.md
+++ b/skills/create-github-issue/SKILL.md
@@ -82,7 +82,7 @@ Parse `OWNER`, `REPO`, and `CHILD_NUMBER` from the issue URL returned in Step 5 
 Run the script once per child issue to link:
 
 ```bash
-skills/create-github-issue/link-sub-issue.sh --owner "$OWNER" --repo "$REPO" --parent "$PARENT_NUMBER" --child "$CHILD_NUMBER"
+~/.claude/skills/create-github-issue/link-sub-issue.sh --owner "$OWNER" --repo "$REPO" --parent "$PARENT_NUMBER" --child "$CHILD_NUMBER"
 ```
 
 The script handles all GraphQL calls internally, using `jq -n` to build payloads via temp files to avoid zsh history expansion stripping `!` from GraphQL type annotations (`String!`, `Int!`, `ID!`). It prints `linked #<child> → #<parent>` on success or an error message on failure (exit 1).

--- a/skills/ensure-gitignore/SKILL.md
+++ b/skills/ensure-gitignore/SKILL.md
@@ -13,7 +13,7 @@ Checks that `.gitignore` contains the sentinel that excludes Claude's ephemeral 
 ## Usage
 
 ```bash
-skills/ensure-gitignore/ensure-gitignore.sh [GITIGNORE_PATH]
+~/.claude/skills/ensure-gitignore/ensure-gitignore.sh [GITIGNORE_PATH]
 ```
 
 **Arguments:**

--- a/skills/file-placement/SKILL.md
+++ b/skills/file-placement/SKILL.md
@@ -24,7 +24,7 @@ When creating a new file, use this decision tree to determine the correct locati
 
 Evaluate from top to bottom. The first matching row determines the destination.
 
-Each skill owns its own file format, naming conventions, and auto-numbering. Consult the referenced skill for specifics. For the numbered working-file skills — `/scratchpad`, `/question`, and `/commit-msg` — directory organization (flat vs issue-scoped subdirectories) is handled by `skills/issue-context/target-path.sh`, which those skills call internally. `/note` uses timestamp-based filenames and detects branch context on its own; `/breadcrumb` writes a single file per issue directly. All ephemeral working files live under `.claude-work/`.
+Each skill owns its own file format, naming conventions, and auto-numbering. Consult the referenced skill for specifics. For the numbered working-file skills — `/scratchpad`, `/question`, and `/commit-msg` — directory organization (flat vs issue-scoped subdirectories) is handled by `~/.claude/skills/issue-context/target-path.sh`, which those skills call internally. `/note` uses timestamp-based filenames and detects branch context on its own; `/breadcrumb` writes a single file per issue directly. All ephemeral working files live under `.claude-work/`.
 
 ## Ephemeral Path Rule
 

--- a/skills/issue-context/SKILL.md
+++ b/skills/issue-context/SKILL.md
@@ -13,7 +13,7 @@ All deterministic logic for "where should this file go?" lives in `target-path.s
 ## Script contract
 
 ```bash
-skills/issue-context/target-path.sh --type <scratchpads|questions|commit-msgs> --description "<text>" [--ext txt]
+~/.claude/skills/issue-context/target-path.sh --type <scratchpads|questions|commit-msgs> --description "<text>" [--ext txt]
 ```
 
 The script reads the current branch, extracts the issue ID (numeric prefix of the segment after `issues/` when applicable, full segment otherwise, empty on non-issue branches), slugifies the description, runs `auto-number.sh` internally, creates the target directory, and prints the full file path on stdout.

--- a/skills/question/SKILL.md
+++ b/skills/question/SKILL.md
@@ -25,11 +25,11 @@ Questions are NEVER printed in terminal output. They go to a file that the user 
 Run these two commands as parallel tool calls — they are independent.
 
 ```bash
-skills/issue-context/target-path.sh --type questions --description "$ARGUMENTS"
+~/.claude/skills/issue-context/target-path.sh --type questions --description "$ARGUMENTS"
 ```
 
 ```bash
-skills/ensure-gitignore/ensure-gitignore.sh
+~/.claude/skills/ensure-gitignore/ensure-gitignore.sh
 ```
 
 Use the stdout of the first command as the full file path. The script handles branch detection, issue-ID extraction, directory creation, auto-numbering, and slug normalization in one call. On an `issues/<ID>` branch the output is `.claude-work/issues/<ID>/questions/NNNN-<slug>.txt`; otherwise `.claude-work/questions/NNNN-<slug>.txt`.

--- a/skills/scratchpad/SKILL.md
+++ b/skills/scratchpad/SKILL.md
@@ -21,11 +21,11 @@ Create or update a working document in `.claude-work/`.
 Run these two commands as parallel tool calls — they are independent.
 
 ```bash
-skills/issue-context/target-path.sh --type scratchpads --description "$ARGUMENTS"
+~/.claude/skills/issue-context/target-path.sh --type scratchpads --description "$ARGUMENTS"
 ```
 
 ```bash
-skills/ensure-gitignore/ensure-gitignore.sh
+~/.claude/skills/ensure-gitignore/ensure-gitignore.sh
 ```
 
 Use the stdout of the first command as the full file path. The script handles branch detection, issue-ID extraction, directory creation, auto-numbering, and slug normalization in one call. On an `issues/<ID>` branch the output is `.claude-work/issues/<ID>/scratchpads/NNNN-<slug>.txt`; otherwise `.claude-work/scratchpads/NNNN-<slug>.txt`.


### PR DESCRIPTION
## Summary

`/scratchpad`, `/question`, `/commit-msg`, and `/create-github-issue` were invoking their foundation scripts via relative paths (`skills/issue-context/target-path.sh`, etc.). Those paths only resolve when Claude runs from the root of the `my-claude-skills` repo itself, so every other project hit `Exit 127: no such file or directory`. This PR switches the four user-facing skills to absolute `~/.claude/skills/...` invocations and updates the foundation-skill contract docs (`/issue-context`, `/ensure-gitignore`, `/auto-number`, `/file-placement`) to the same pattern so future callers copy a working snippet.

## Changes

- `/scratchpad`, `/question`, `/commit-msg` — Step 1 bash blocks now call `~/.claude/skills/issue-context/target-path.sh` and `~/.claude/skills/ensure-gitignore/ensure-gitignore.sh`
- `/create-github-issue` — Step 6 `link-sub-issue.sh` invocation switched to absolute path
- Contract docs (`/issue-context`, `/ensure-gitignore`, `/auto-number`) — usage examples updated to the absolute form for consistency; `/file-placement` inline reference updated to match

## Key Discoveries

- `allowed-tools` patterns were already written as `Bash(*/skills/.../*.sh *)` with a leading `*/` glob — they anticipated absolute paths. The bug was in the prose instructions, not the permission layer, so no `allowed-tools` change was needed
- The bug was introduced in https://github.com/couimet/my-claude-skills/pull/122 (https://github.com/couimet/my-claude-skills/issues/120) when path resolution moved into `target-path.sh`; the new Step 1 blocks inlined the relative path instead of resolving it against the install location

## Related

- Orthogonal improvement discovered during active development — no associated issue
- Regressed from https://github.com/couimet/my-claude-skills/pull/122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path resolution errors in multiple skills by updating references to use absolute installation paths
  * Resolves "Exit 127: no such file or directory" errors when skills are invoked from outside the repository
  * Skills now reliably execute from any working directory location

* **Documentation**
  * Updated skill documentation to reflect correct absolute path references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->