### PR TITLE
[issues/128] Fix `setup.sh` to install `bats-core`

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,9 +24,15 @@ brew install markdownlint-cli2
 
 echo "✓ markdownlint-cli2 installed: $(markdownlint-cli2 --version)"
 
+# Install bats-core
+echo "📦 Installing bats-core..."
+brew install bats-core
+
+echo "✓ bats-core installed: $(bats --version)"
+
 echo ""
 echo "✅ Setup complete!"
 echo ""
 echo "Next steps:"
-echo "  Run make lint before pushing a PR"
+echo "  Run make lint && make test before pushing a PR"
 echo ""


### PR DESCRIPTION
## Summary

`setup.sh` only installed `markdownlint-cli2`, leaving `bats-core` off PATH. Any contributor who ran `./setup.sh` and then `make test` hit an immediate failure. This adds the missing install so the full `make all` workflow works after a single setup step.

## Changes

- Added `brew install bats-core` and version echo to `setup.sh`
- Updated "Next steps" footer to reference `make lint && make test`

## Test Plan

- [x] All existing tests pass (147/147)
- [ ] New tests added for: N/A — setup script change
- [x] Manual testing: run `./setup.sh` on a machine without `bats-core`, verify `make test` succeeds

## Related

Closes https://github.com/couimet/my-claude-skills/issues/128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Setup script now installs `bats-core` testing framework alongside existing tools.
  * Updated development requirements to run both linting and tests before pushing PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->