### PR TITLE
[issues/127] Link new dev.to article in `Featured In`

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ The [`demo/real-life/issues-10/`](demo/real-life/issues-10/) folder contains eve
 
 The most recent posts are at the top.
 
+- [I Thought I Was DRY-ing, I May Have Been Double-Paying](https://dev.to/couimet/i-thought-i-was-dry-ing-i-may-have-been-double-paying-5dli) - DEV Community
 - [From Vide Coding to Supercharged Vibe Guiding](https://dev.to/couimet/from-vide-coding-to-supercharged-vibe-guiding-6nm) - DEV Community
 - [From Blank Issue to PR — With the Thinking Exposed](https://ouimet.info/follow-alongs/my-claude-skills-issues-10.html) — a full follow-along showing how these skills turned a blank issue into a shipped PR, with every artifact visible
 


### PR DESCRIPTION
## Summary

Adds a link to a new dev.to article in the README `## Featured In` section. The section lists most-recent-first; the new entry goes at the top.

## Changes

- Added "I Thought I Was DRY-ing, I May Have Been Double-Paying" to the Featured In list

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new featured DEV Community article to the "Featured In" section in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->