### PR TITLE
[issues/132] Skip `/commit-msg` in single-block note and scratchpad flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.04.27
+
+### Changed
+
+- `/start-issue` now explicitly instructs the LLM to call `/finish-issue` directly after note-based implementation — skipping `/commit-msg`, which is redundant when a single session covers all the work. `/tackle-scratchpad-block`'s note-flow STOP message gains the same "When done, call `/finish-issue` directly" reminder ([issues/132](https://github.com/couimet/my-claude-skills/issues/132))
+
 ## 2026.04.24
 
 ### Changed

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -131,8 +131,8 @@ Print the branch name, the working-document path, the active-plan pointer path, 
 ```text
 Next: review the plan, then ask me to proceed with the first step (e.g. "start S1" or just "go ahead").
 I will self-organize execution using the note as reference.
-Commit model: one commit at the end covering all changes. Run /finish-issue when done —
-its PR description file doubles as the commit message body.
+Commit model: one commit at the end covering all changes. When done, call /finish-issue directly —
+do NOT call /commit-msg first. The PR description file doubles as the commit message body.
 ```
 
 **Opt-in path (scratchpad):**

--- a/skills/tackle-scratchpad-block/SKILL.md
+++ b/skills/tackle-scratchpad-block/SKILL.md
@@ -37,6 +37,8 @@ in-session task tracking. To proceed, choose one of:
        /tackle-scratchpad-block path/to/plan.txt#S001
 
   C. Proceed manually — ask Claude to implement the next step from the note directly.
+
+When done with implementation, call /finish-issue directly — do NOT call /commit-msg first.
 ```
 
 ## Step 1: Read the Target Block


### PR DESCRIPTION
## Summary

Since PR #130 made the note-based flow the default, the typical execution pattern completes all implementation in a single LLM session. In that pattern, calling `/commit-msg` before `/finish-issue` is redundant — the PR description that `/finish-issue` produces already serves as the commit body. This PR closes the gap by making the prohibition explicit in two places where the LLM self-organizes wrap-up.

## Changes

- `skills/start-issue/SKILL.md`: the Step 6 default-path "Next" block now reads "call `/finish-issue` directly — do NOT call `/commit-msg` first" instead of the previous implicit guidance
- `skills/tackle-scratchpad-block/SKILL.md`: the Step 0 STOP message (note-flow branch) now appends "When done with implementation, call `/finish-issue` directly — do NOT call `/commit-msg` first"
- Documentation: CHANGELOG entry added for 2026.04.27; README not needed — no new user-facing commands or settings

## Test Plan

- [x] All 147 existing tests pass (`make lint && make test`)
- [ ] No new tests needed — changes are LLM guidance prose only

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill workflow instructions to clarify the completion process after note-based implementation.
  * Workflows now direct users to call `/finish-issue` directly, omitting the `/commit-msg` intermediate step when both occur in the same session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->