### PR TITLE
[issues/134] fix: target-path.sh accepts `notes` as a valid `--type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.05.01
+
+### Fixed
+
+- `target-path.sh` now accepts `notes` as a valid `--type` value, producing `.claude-work/issues/<ID>/notes/NNNN-<slug>.txt` on issue branches and `.claude-work/notes/NNNN-<slug>.txt` elsewhere. Previously, callers that passed `--type notes` received a `T100` error because `notes` was missing from the allowlist. The `/issue-context` SKILL.md contract signature is updated to match ([issues/134](https://github.com/couimet/my-claude-skills/issues/134))
+
 ## 2026.04.27
 
 ### Changed

--- a/skills/issue-context/SKILL.md
+++ b/skills/issue-context/SKILL.md
@@ -13,7 +13,7 @@ All deterministic logic for "where should this file go?" lives in `target-path.s
 ## Script contract
 
 ```bash
-~/.claude/skills/issue-context/target-path.sh --type <scratchpads|questions|commit-msgs> --description "<text>" [--ext txt]
+~/.claude/skills/issue-context/target-path.sh --type <scratchpads|questions|commit-msgs|notes> --description "<text>" [--ext txt]
 ```
 
 The script reads the current branch, extracts the issue ID (numeric prefix of the segment after `issues/` when applicable, full segment otherwise, empty on non-issue branches), slugifies the description, runs `auto-number.sh` internally, creates the target directory, and prints the full file path on stdout.

--- a/skills/issue-context/target-path.sh
+++ b/skills/issue-context/target-path.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: target-path.sh --type <scratchpads|questions|commit-msgs> --description <text> [--ext <ext>]
+Usage: target-path.sh --type <scratchpads|questions|commit-msgs|notes> --description <text> [--ext <ext>]
 
   --type         File category (required)
   --description  Free-form text for the slug (required)
@@ -81,13 +81,13 @@ done
 
 # --- Validate type ---
 case "$type_arg" in
-  scratchpads|questions|commit-msgs) ;;
+  scratchpads|questions|commit-msgs|notes) ;;
   "")
     echo "target-path $ERR_MISSING_ARG error: --type is required" >&2
     exit 1
     ;;
   *)
-    echo "target-path $ERR_INVALID_TYPE error: invalid --type '$type_arg' (expected scratchpads, questions, or commit-msgs)" >&2
+    echo "target-path $ERR_INVALID_TYPE error: invalid --type '$type_arg' (expected scratchpads, questions, commit-msgs, or notes)" >&2
     exit 1
     ;;
 esac

--- a/skills/issue-context/target-path.sh
+++ b/skills/issue-context/target-path.sh
@@ -6,7 +6,7 @@
 #
 # Usage: target-path.sh --type <type> --description <text> [--ext <ext>]
 #
-#   --type         "scratchpads", "questions", or "commit-msgs" (required)
+#   --type         "scratchpads", "questions", "commit-msgs", or "notes" (required)
 #   --description  Free-form text for the slug (required; will be lowercased +
 #                  hyphenated)
 #   --ext          File extension without the dot. Alphanumeric only (e.g.

--- a/tests/target-path.bats
+++ b/tests/target-path.bats
@@ -192,6 +192,20 @@ teardown() {
   [[ "$output" == *"T001"* ]]
 }
 
+@test "notes type on issue branch → issue-scoped notes path" {
+  git checkout -q -b issues/42
+  run "$SCRIPT" --type notes --description "Plan the work"
+  [ "$status" -eq 0 ]
+  [ "$output" = ".claude-work/issues/42/notes/0001-plan-the-work.txt" ]
+}
+
+@test "notes type on main branch → flat-root notes path" {
+  git checkout -q -B main
+  run "$SCRIPT" --type notes --description "Quick finding"
+  [ "$status" -eq 0 ]
+  [ "$output" = ".claude-work/notes/0001-quick-finding.txt" ]
+}
+
 @test "invalid --type errors with T100" {
   run "$SCRIPT" --type bogus --description "test"
   [ "$status" -eq 1 ]


### PR DESCRIPTION
## Summary

`target-path.sh` rejected `--type notes` with a `T100` error because `notes` was missing from the type allowlist — only `scratchpads`, `questions`, and `commit-msgs` were accepted. This fix adds `notes` as a fourth valid type so callers that route through the script rather than the self-contained `/note` skill no longer hit the error.

## Changes

- `skills/issue-context/target-path.sh`: added `notes` to the `case` whitelist; updated the usage string and T100 error message to list all four valid types
- `skills/issue-context/SKILL.md`: updated script contract signature to show `<scratchpads|questions|commit-msgs|notes>`
- `tests/target-path.bats`: added two tests for the `notes` type — issue branch (`.claude-work/issues/<ID>/notes/0001-<slug>.txt`) and non-issue branch (`.claude-work/notes/0001-<slug>.txt`)
- Documentation: CHANGELOG entry added under `### Fixed`; README not needed — no user-facing command or setting changed

## Test Plan

- [x] All existing tests pass (149/149)
- [x] New tests added for `notes` type: issue-branch path and flat-root path

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended target-path functionality to recognize and properly handle `notes` as a valid type parameter, resolving T100 allowlist errors that previously occurred when this type was used.

* **Documentation**
  * Updated contract documentation to reflect the extended set of supported type values.

* **Tests**
  * Added tests validating notes type behavior across different branch contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->