### PR TITLE
[issues/136] Optimize skill prose: em dashes, positive phrasing, output anchors, anti-AI self-checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Contributors are encouraged to add a changelog entry with their PR, but it's not
 
 - Skill prose updated across all 20 skills to follow LinkedIn-post prompt-optimization advice: em dashes replaced with standard punctuation, negative instructions rephrased positively where it improves clarity, and text-producing skills now include explicit Length/Format/Tone output anchors. Self-checks in text-producing skills now also skim for common AI-writing patterns like filler phrases and vague conclusions ([issues/136](https://github.com/couimet/my-claude-skills/issues/136))
 
+### Fixed
+
+- `/ensure-gitignore` now always targets the project root `.gitignore` (resolved via `git rev-parse --show-toplevel`) instead of resolving relative to the current working directory, preventing accidental `.gitignore` creation in subdirectories
+
 ## 2026.05.01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.05.15
+
+### Changed
+
+- Skill prose updated across all 20 skills to follow LinkedIn-post prompt-optimization advice: em dashes replaced with standard punctuation, negative instructions rephrased positively where it improves clarity, and text-producing skills now include explicit Length/Format/Tone output anchors. Self-checks in text-producing skills now also skim for common AI-writing patterns like filler phrases and vague conclusions ([issues/136](https://github.com/couimet/my-claude-skills/issues/136))
+
 ## 2026.05.01
 
 ### Fixed

--- a/skills/auto-number/SKILL.md
+++ b/skills/auto-number/SKILL.md
@@ -19,7 +19,7 @@ Returns the next available sequence number for files in a directory. Run the scr
 **Arguments:**
 
 - `directory` (required, positional) -- path to scan for existing numbered files
-- `--mode` (optional) -- `prefix` for `NNNN-name.ext` or `suffix` for `name-NNNN.ext`. Default: `prefix`. **Omit `--mode` entirely when you want prefix mode** — it is the default.
+- `--mode` (optional) -- `prefix` for `NNNN-name.ext` or `suffix` for `name-NNNN.ext`. Default: `prefix`. **Omit `--mode` entirely when you want prefix mode**: it is the default.
 - `--glob` (optional) -- file filter pattern (e.g., `*.txt`). Default: all files
 - `--width` (optional) -- output width, 1-10. Default: 4. Safety: never truncates if next value needs more digits
 
@@ -29,7 +29,7 @@ Returns the next available sequence number for files in a directory. Run the scr
 
 ```bash
 # Next prefix number in .claude-work/issues/5/commit-msgs/ (default mode, default width)
-# NOTE: do NOT pass "prefix" as a positional argument — just omit --mode
+# NOTE: do NOT pass "prefix" as a positional argument. Just omit --mode
 ~/.claude/skills/auto-number/auto-number.sh .claude-work/issues/5/commit-msgs
 
 # Next suffix number, only counting .json files
@@ -41,20 +41,20 @@ Returns the next available sequence number for files in a directory. Run the scr
 
 ## Common Mistakes
 
-**WRONG** — `prefix` is not a positional argument:
+**WRONG**: `prefix` is not a positional argument:
 
 ```bash
 # This will fail with: E002 error: unexpected argument 'prefix'
 ~/.claude/skills/auto-number/auto-number.sh .claude-work/issues/5/scratchpads prefix
 ```
 
-**RIGHT** — omit `--mode` entirely for prefix (it is the default):
+**RIGHT**: omit `--mode` entirely for prefix (it is the default):
 
 ```bash
 ~/.claude/skills/auto-number/auto-number.sh .claude-work/issues/5/scratchpads
 ```
 
-**RIGHT** — use `--mode` flag when explicitly specifying a mode:
+**RIGHT**: use `--mode` flag when explicitly specifying a mode:
 
 ```bash
 ~/.claude/skills/auto-number/auto-number.sh .claude-work/issues/5/scratchpads --mode suffix

--- a/skills/breadcrumb/SKILL.md
+++ b/skills/breadcrumb/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Read, Write, Bash(git branch --show-current), Bash(date *), Bash(
 
 # Breadcrumb
 
-Drop a timestamped note along your journey through an issue. When you run `/finish-issue`, it follows the trail back — collecting all discoveries, decisions, and reminders.
+Drop a timestamped note along your journey through an issue. When you run `/finish-issue`, it follows the trail back, collecting all discoveries, decisions, and reminders.
 
 **Input:** $ARGUMENTS (the note text to record)
 
@@ -74,7 +74,7 @@ Print a brief confirmation with the file path:
 - Issues: `Breadcrumb dropped in .claude-work/issues/<ID>/breadcrumb.md`
 - Side-quests: `Breadcrumb dropped in .claude-work/breadcrumb-<slug>.md`
 
-Do NOT print the full file contents — keep it minimal.
+Confirm by printing the path as shown above. Length: one line. Do NOT print the full file contents.
 
 ## Formatting
 

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Read, Edit, Bash(git log *), Bash(git diff *), Bash(git branch --
 
 # Changelog
 
-Create a CHANGELOG entry with built-in guardrails for tone, placement, and detail-leak detection. Writes directly to CHANGELOG.md — the user reviews via `git diff` before committing.
+Create a CHANGELOG entry with built-in guardrails for tone, placement, and detail-leak detection. Writes directly to CHANGELOG.md. The user reviews via `git diff` before committing.
 
 **Input:** $ARGUMENTS (a short description of the change, e.g. "binding survives language-mode changes")
 
@@ -27,13 +27,13 @@ If no CHANGELOG.md exists anywhere, STOP: "No CHANGELOG.md found. Create one fir
 
 Read the target CHANGELOG.md and the project's CLAUDE.md (if it exists) to understand:
 
-- **Versioning scheme** — detect from the file's own header or preamble. Common patterns:
+- **Versioning scheme**: detect from the file's own header or preamble. Common patterns:
   - **SemVer:** headings like `## [1.2.3]` or `## [Unreleased]`, often with a preamble referencing [semver.org](https://semver.org) or [Keep a Changelog](https://keepachangelog.com)
   - **CalVer:** headings like `## 2026.03.19`, often with a preamble referencing [calver.org](https://calver.org)
   - **Other:** match whatever heading pattern the file uses
-- **Category subsections** — typically `### Added`, `### Changed`, `### Fixed`, `### Removed` (Keep a Changelog style). Some projects use different categories — match what exists.
-- **Entry format** — how entries are written, how issue links are formatted, what style the project uses.
-- **Existing entries** — scan the most recent section(s) to understand the project's voice and level of detail.
+- **Category subsections**: typically `### Added`, `### Changed`, `### Fixed`, `### Removed` (Keep a Changelog style). Some projects use different categories. Match what exists.
+- **Entry format**: how entries are written, how issue links are formatted, what style the project uses.
+- **Existing entries**: scan the most recent section(s) to understand the project's voice and level of detail.
 
 Also check the project's CLAUDE.md for any explicit CHANGELOG conventions (heading format, link style, category rules). CLAUDE.md overrides inferred conventions.
 
@@ -73,7 +73,7 @@ Determine where to place the entry based on the versioning scheme detected in St
 
 **SemVer projects (with `[Unreleased]` section):**
 
-- If an `## [Unreleased]` section exists, place the entry there — this is the standard SemVer workflow for in-progress changes.
+- If an `## [Unreleased]` section exists, place the entry there. This is the standard SemVer workflow for in-progress changes.
 - If no `[Unreleased]` section exists, create one above the most recent versioned heading.
 
 **CalVer projects (date-based headings):**
@@ -99,8 +99,8 @@ Before drafting, read 3-5 recent entries in the CHANGELOG to match the project's
 
 Scan the draft entry against the blocklist patterns (see Implementation-Detail Blocklist section). For each match:
 
-- Print a warning: `Possible implementation detail: "<matched text>" — consider rephrasing in user-facing terms`
-- Do NOT block — the user may have a legitimate reason to include the detail
+- Print a warning: `Possible implementation detail: "<matched text>"` Consider rephrasing in user-facing terms
+- Do NOT block. The user may have a legitimate reason to include the detail
 
 If no matches, proceed silently.
 
@@ -112,7 +112,7 @@ Scan the entries in the target section's category subsection for thematic proxim
 2. If a match is found, place the new entry adjacent to the closest match (after it)
 3. If no match is found, append at the end of the subsection
 
-When creating a new version heading, placement is straightforward — the entry is the first in its subsection.
+When creating a new version heading, placement is straightforward. The entry is the first in its subsection.
 
 ## Step 8: Present and Write
 
@@ -137,7 +137,7 @@ These rules ensure entries describe what users experience, not how the code work
 
 - **Lead with what the user sees:** "Binding survives language-mode changes" not "Fixed onDidCloseTextDocument firing during language-mode switch"
 - **Describe the symptom, not the mechanism:** "no longer silently breaks" not "now checks isClosed flag before re-registering"
-- **One sentence for the change, optionally one for previous behavior** — no more
+- **One sentence for the change, optionally one for previous behavior**. No more
 - **Use the feature name as the subject** when the change is about a specific feature
 
 ### Don't
@@ -149,7 +149,7 @@ These rules ensure entries describe what users experience, not how the code work
 
 ### Examples
 
-**Good (SemVer project — a task management app):**
+**Good (SemVer project, a task management app):**
 
 ```text
 - Search results now highlight matched terms in the preview pane ([#42](https://github.com/acme/taskflow/issues/42))
@@ -161,7 +161,7 @@ These rules ensure entries describe what users experience, not how the code work
 - Added ElasticSearch highlight fragments to SearchResultDTO and mapped them through the PreviewRenderer pipeline with dangerouslySetInnerHTML for term emphasis ([#42](https://github.com/acme/taskflow/issues/42))
 ```
 
-**Good (CalVer project — a CLI tool):**
+**Good (CalVer project, a CLI tool):**
 
 ```text
 - `deploy` command now retries on transient network errors instead of failing immediately ([issues/87](https://github.com/acme/shipit/issues/87))
@@ -175,7 +175,7 @@ These rules ensure entries describe what users experience, not how the code work
 
 ## Implementation-Detail Blocklist
 
-Flag entries containing these patterns. Warn but do not block — rare edge cases may legitimately include a technical name.
+Flag entries containing these patterns. Warn but do not block. Rare edge cases may legitimately include a technical name.
 
 | Pattern | Why it's flagged |
 | --- | --- |
@@ -192,12 +192,14 @@ Flag entries containing these patterns. Warn but do not block — rare edge case
 
 Before placing an entry, scan the target subsection for thematic proximity:
 
-1. **Same feature or command name** — entries mentioning the same feature, command, or module name are the strongest match
-2. **Same user workflow** — entries about the same user-facing workflow (e.g., "search", "deploy", "authentication")
-3. **Same component area** — entries about the same part of the system (e.g., "CI", "build", "tests", "config")
+1. **Same feature or command name**: entries mentioning the same feature, command, or module name are the strongest match
+2. **Same user workflow**: entries about the same user-facing workflow (e.g., "search", "deploy", "authentication")
+3. **Same component area**: entries about the same part of the system (e.g., "CI", "build", "tests", "config")
 
 Place the new entry after the last thematic match in the subsection. If no match exists, append at the end.
 
 ## Formatting
 
 See `/prose-style` for hard-wrap and GitHub-reference rules.
+
+Before writing the entry, skim the text for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -93,6 +93,8 @@ Write the entry following the tone rules (see Tone Rules section below). The ent
 2. Be one sentence for the change, optionally one for previous behavior
 3. End with an issue reference following the project's link format (read from existing entries to match the convention)
 
+Each bullet covers a single distinct change. When a PR or issue includes multiple unrelated changes, write separate bullets — do not chain them together with periods or semicolons into a single entry. The "one sentence" rule is per change, not per category subsection.
+
 Before drafting, read 3-5 recent entries in the CHANGELOG to match the project's voice and formatting conventions.
 
 ## Step 6: Implementation-Detail Check

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -93,7 +93,7 @@ Write the entry following the tone rules (see Tone Rules section below). The ent
 2. Be one sentence for the change, optionally one for previous behavior
 3. End with an issue reference following the project's link format (read from existing entries to match the convention)
 
-Each bullet covers a single distinct change. When a PR or issue includes multiple unrelated changes, write separate bullets — do not chain them together with periods or semicolons into a single entry. The "one sentence" rule is per change, not per category subsection.
+Each bullet covers a single distinct change. When a PR or issue includes multiple unrelated changes, write separate bullets. Do not chain them together with periods or semicolons into a single entry. The "one sentence" rule is per change, not per category subsection.
 
 Before drafting, read 3-5 recent entries in the CHANGELOG to match the project's voice and formatting conventions.
 

--- a/skills/cleanup-issue/SKILL.md
+++ b/skills/cleanup-issue/SKILL.md
@@ -83,7 +83,7 @@ rm -rf .claude-work/issues/<ID>
 Print:
 
 ```text
-Cleaned up .claude-work/issues/<ID>/ — all working files removed.
+Cleaned up .claude-work/issues/<ID>/. All working files removed.
 ```
 
 ## Step 5: Check for Side-Quest Artifacts

--- a/skills/commit-msg/SKILL.md
+++ b/skills/commit-msg/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: commit-msg
 version: 2026.05.01@e2913b7
-description: Create a commit message file in .claude-work/commit-msgs/ with auto-numbered filenames. Focuses on WHY not WHAT — the diff already shows what changed. User reviews and commits manually.
+description: Create a commit message file in .claude-work/commit-msgs/ with auto-numbered filenames. Focuses on WHY not WHAT. The diff already shows what changed. User reviews and commits manually.
 argument-hint: <description>
 allowed-tools: Read, Write, Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
 ---
 
 # Commit Message
 
-Create a commit message file in `.claude-work/`. The user reviews and runs `git commit` themselves.
+Create a commit message file in `.claude-work/`. You write the message, the user reviews and runs `git commit` themselves.
 
 **Input:** $ARGUMENTS (a short description for the filename)
 
@@ -18,11 +18,11 @@ Create a commit message file in `.claude-work/`. The user reviews and runs `git 
 
 ## Core Principle
 
-Focus on **WHY**, not **WHAT**. The git diff already shows what changed — the commit message explains the motivation, the problem being solved, and the benefits. Message depth should scale with the cognitive load of the change — not every commit needs a body or Benefits section.
+Focus on **WHY**, not **WHAT**. The git diff already shows what changed. The commit message explains the motivation, the problem being solved, and the benefits. Message depth should scale with the cognitive load of the change. Not every commit needs a body or Benefits section.
 
 ## Step 1: Resolve the Target Path
 
-Run these two commands as parallel tool calls — they are independent.
+Run these two commands as parallel tool calls. They are independent.
 
 ```bash
 ~/.claude/skills/issue-context/target-path.sh --type commit-msgs --description "$ARGUMENTS"
@@ -38,11 +38,11 @@ Use the stdout of the first command as the full file path. The script handles br
 
 Before writing, assess the change and pick a tier. The heuristic: if you can't articulate a "why" that isn't just restating the subject, it's trivial. If the "why" fits in two sentences without needing to list outcomes, it's moderate.
 
-**Trivial** — subject line only. Use for: CHANGELOG / docs-only updates, renaming / moving files, bumping versions or dependencies, deleting dead code, fixing typos.
+**Trivial**: subject line only. Use for: CHANGELOG / docs-only updates, renaming / moving files, bumping versions or dependencies, deleting dead code, fixing typos.
 
-**Moderate** — subject + 1-2 sentence body. Use for: bug fixes, small refactors, config changes with non-obvious motivation. The body explains why.
+**Moderate**: subject + 1-2 sentence body. Use for: bug fixes, small refactors, config changes with non-obvious motivation. The body explains why.
 
-**Substantial** — subject + body + Benefits list. Use for: new features or capabilities, architectural changes, multi-file behavioral changes, performance improvements, security fixes.
+**Substantial**: subject + body + Benefits list. Use for: new features or capabilities, architectural changes, multi-file behavioral changes, performance improvements, security fixes.
 
 ## File Format
 
@@ -50,7 +50,7 @@ Files use `.txt` extension (not `.md`).
 
 ### First Line (all tiers)
 
-`[type] <summary>` — imperative mood, no period, under 72 characters.
+`[type] <summary>`: imperative mood, no period, under 72 characters.
 
 Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`, `style`
 
@@ -83,10 +83,17 @@ Benefits:
 
 ### Rules
 
-1. **No file lists** — redundant with the diff
-2. **Length** — trivial: 1 line; moderate: 3-5 lines; substantial: under 15 lines
-3. **Never include the current working issue link** — `/finish-issue` adds the `Closes` link to the PR description. That's the single source of truth for issue linkage. Repeating it in commit messages is redundant noise.
-4. **Other issue/PR references are fine** — when they add context (e.g., "fixes regression from `https://github.com/.../pull/42`"), include them.
+1. **No file lists**. Redundant with the diff.
+2. **Length**: 1 line (trivial), 3-5 lines (moderate), under 15 lines (substantial).
+3. **Keep the working issue link in the PR description only.** `/finish-issue` adds the `Closes` link there. That is the single source of truth for issue linkage. Repeating it in commit messages is redundant noise.
+4. **Other issue/PR references are fine** when they add context (e.g., "fixes regression from `https://github.com/.../pull/42`"), include them.
+
+### Output Anchors
+
+Subject: [type] summary, imperative mood, no period, under 72 characters.
+Length: 1 line (trivial), 3-5 lines (moderate), under 15 lines (substantial).
+Format: plain text, no markdown. One continuous line per paragraph.
+Tone: professional, specific, why-focused.
 
 Formatting: see `/prose-style` for hard-wrap and GitHub-reference rules.
 
@@ -94,6 +101,6 @@ Formatting: see `/prose-style` for hard-wrap and GitHub-reference rules.
 
 1. Assess the change complexity (trivial, moderate, or substantial)
 2. Create the file using the matching tier format
-3. **Self-check for hard-wrapping.** Re-read the file you just wrote. For each paragraph in the body (text between blank lines, outside code blocks and the Benefits bullet list), verify it is a single continuous line. If you find a mid-sentence line break, rewrite that paragraph as one line. This check catches the most common failure — do not skip it.
+3. **Self-check for hard-wrapping.** Re-read the file you just wrote. For each paragraph in the body (text between blank lines, outside code blocks and the Benefits bullet list), verify it is a single continuous line. If you find a mid-sentence line break, rewrite that paragraph as one line. This check catches the most common failure. Always complete it. Also skim for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.
 4. Print the filepath in terminal
-5. Do NOT run `git commit` — the user reviews and commits manually
+5. Do NOT run `git commit`. The user reviews and commits manually.

--- a/skills/create-github-issue/SKILL.md
+++ b/skills/create-github-issue/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: create-github-issue
 version: 2026.05.01@e2913b7
-description: Create a GitHub issue from a file draft or inline description — with smart label discovery and sub-issue linking
+description: Create a GitHub issue from a file draft or inline description, with smart label discovery and sub-issue linking
 argument-hint: <file-path-or-title>
 allowed-tools: Read, Write, Glob, Bash(gh repo view *), Bash(gh label list *), Bash(gh issue create *), Bash(*/skills/create-github-issue/link-sub-issue.sh *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
 ---
 
 # Create GitHub Issue
 
-Create a GitHub issue with smart label discovery and optional sub-issue linking. Reads from any file (scratchpad, markdown, extensionless — including drag-dropped paths) or accepts an inline title.
+Create a GitHub issue with smart label discovery and optional sub-issue linking. Reads from any file (scratchpad, markdown, extensionless, including drag-dropped paths) or accepts an inline title.
 
 **Input:** $ARGUMENTS (a file path, or a title for interactive creation)
 
@@ -16,8 +16,8 @@ Create a GitHub issue with smart label discovery and optional sub-issue linking.
 
 Determine the input mode from `$ARGUMENTS`:
 
-- **File path** — if the argument points to an existing file (any path, any extension or none), treat it as a draft to extract from. This covers `.claude-work/scratchpads/*.txt`, markdown files, extensionless files, and drag-dropped paths from the terminal.
-- **Inline title** — otherwise, treat the entire argument as the issue title for interactive creation.
+- **File path**: if the argument points to an existing file (any path, any extension or none), treat it as a draft to extract from. This covers `.claude-work/scratchpads/*.txt`, markdown files, extensionless files, and drag-dropped paths from the terminal.
+- **Inline title**: otherwise, treat the entire argument as the issue title for interactive creation.
 
 ## Step 2: Extract Issue Content
 
@@ -25,8 +25,8 @@ Determine the input mode from `$ARGUMENTS`:
 
 Read the file and extract:
 
-- **Title** — the first `#`-level heading (strip the `#` prefix)
-- **Body** — everything after the title heading
+- **Title**: the first `#`-level heading (strip the `#` prefix)
+- **Body**: everything after the title heading
 
 If the file contains a `## Parent` or `Parent: #NN` line, extract the parent issue number for sub-issue linking in Step 6.
 
@@ -34,7 +34,7 @@ If the file contains a `**Target repo:** owner/repo` line (e.g., `**Target repo:
 
 ### From Inline Title
 
-Use the argument as the title. Prompt the user to provide a body — either inline or by pointing to an existing file.
+Use the argument as the title. Prompt the user to provide a body, either inline or by pointing to an existing file.
 
 ## Step 3: Sanitize Body
 
@@ -53,7 +53,7 @@ Stripped ephemeral references:
 If no ephemeral references were found, print:
 
 ```text
-No ephemeral references found — body is clean.
+No ephemeral references found. Body is clean.
 ```
 
 ## Step 4: Discover Labels and Prompt for Selection
@@ -90,7 +90,7 @@ The script handles all GraphQL calls internally, using `jq -n` to build payloads
 If the script fails, note it in the Step 7 report as:
 
 ```text
-Sub-issue linking: failed (<error summary>) — link manually if needed.
+Sub-issue linking: failed (<error summary>). Link manually if needed.
 ```
 
 If no parent was specified, skip this step.
@@ -104,7 +104,7 @@ Created: <ISSUE_URL>
 Title: <TITLE>
 Labels: <LABEL1>, <LABEL2>
 Parent: https://github.com/{OWNER}/{REPO}/issues/{PARENT_NUMBER} (linked as sub-issue)  ← only if parent specified AND linking succeeded
-Sub-issue linking: failed (<error summary>) — link manually if needed.  ← only if parent specified AND linking failed
+Sub-issue linking: failed (<error summary>). Link manually if needed.  ← only if parent specified AND linking failed
 ```
 
 Formatting: see `/prose-style` for hard-wrap, code-reference, and GitHub-reference rules.

--- a/skills/ensure-gitignore/SKILL.md
+++ b/skills/ensure-gitignore/SKILL.md
@@ -2,13 +2,13 @@
 name: ensure-gitignore
 version: 2026.05.01@e2913b7
 user-invocable: false
-description: Ensures .gitignore contains the Claude skill working directory sentinel. Shell script handles check-and-append in one Bash call — no file contents loaded into context.
+description: Ensures the project root .gitignore contains the Claude skill working directory sentinel. Shell script handles check-and-append in one Bash call. No file contents loaded into context.
 allowed-tools: Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
 ---
 
 # Ensure Gitignore
 
-Checks that `.gitignore` contains the sentinel that excludes Claude's ephemeral working directory. Appends the block if missing.
+Checks that the project root `.gitignore` contains the sentinel that excludes Claude's ephemeral working directory. Appends the block if missing. Always targets the git repository root — never creates or modifies `.gitignore` files in subdirectories.
 
 ## Usage
 
@@ -18,7 +18,7 @@ Checks that `.gitignore` contains the sentinel that excludes Claude's ephemeral 
 
 **Arguments:**
 
-- `GITIGNORE_PATH` (optional) — path to the `.gitignore` file. Default: `.gitignore` in the current working directory.
+- `GITIGNORE_PATH` (optional): path to the `.gitignore` file. Default: the git repository root's `.gitignore` (resolved via `git rev-parse --show-toplevel`). The script never creates or modifies `.gitignore` files in subdirectories.
 
 **Output:** A single line on stdout: `present` (sentinel already exists, no change) or `added` (block was appended).
 

--- a/skills/ensure-gitignore/ensure-gitignore.sh
+++ b/skills/ensure-gitignore/ensure-gitignore.sh
@@ -18,7 +18,15 @@
 
 set -euo pipefail
 
-GITIGNORE="${1:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.gitignore}"
+if [[ -n "${1:-}" ]]; then
+  GITIGNORE="$1"
+else
+  GITIGNORE="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "Unable to determine repository root; please run from inside a git repo or pass a target .gitignore path" >&2
+    exit 1
+  }
+  GITIGNORE="$GITIGNORE/.gitignore"
+fi
 SENTINEL="# Claude skill working directories"
 BLOCK=".claude-work/"
 

--- a/skills/ensure-gitignore/ensure-gitignore.sh
+++ b/skills/ensure-gitignore/ensure-gitignore.sh
@@ -6,7 +6,7 @@
 # Usage: ensure-gitignore.sh [GITIGNORE_PATH]
 #
 # Arguments:
-#   GITIGNORE_PATH  Optional path to the .gitignore file (default: .gitignore)
+#   GITIGNORE_PATH  Optional path to the .gitignore file (default: project root's .gitignore, resolved via git rev-parse --show-toplevel)
 #
 # Output (one line on stdout):
 #   present  — sentinel already in file; no changes made
@@ -18,7 +18,7 @@
 
 set -euo pipefail
 
-GITIGNORE="${1:-.gitignore}"
+GITIGNORE="${1:-$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.gitignore}"
 SENTINEL="# Claude skill working directories"
 BLOCK=".claude-work/"
 

--- a/skills/file-placement/SKILL.md
+++ b/skills/file-placement/SKILL.md
@@ -26,11 +26,11 @@ When creating a new file, use this decision tree to determine the correct locati
 
 Evaluate from top to bottom. The first matching row determines the destination.
 
-Each skill owns its own file format, naming conventions, and auto-numbering. Consult the referenced skill for specifics. For the numbered working-file skills — `/scratchpad`, `/question`, and `/commit-msg` — directory organization (flat vs issue-scoped subdirectories) is handled by `~/.claude/skills/issue-context/target-path.sh`, which those skills call internally. `/note` uses timestamp-based filenames and detects branch context on its own; `/breadcrumb` writes a single file per issue directly. All ephemeral working files live under `.claude-work/`.
+Each skill owns its own file format, naming conventions, and auto-numbering. Consult the referenced skill for specifics. For the numbered working-file skills: `/scratchpad`, `/question`, and `/commit-msg`. Directory organization (flat vs issue-scoped subdirectories) is handled by `~/.claude/skills/issue-context/target-path.sh`, which those skills call internally. `/note` uses timestamp-based filenames and detects branch context on its own; `/breadcrumb` writes a single file per issue directly. All ephemeral working files live under `.claude-work/`.
 
 ## Ephemeral Path Rule
 
-`.claude-work/` paths must never appear in commits, PRs, GitHub issues, or any output visible on GitHub. These files are local-only working documents that don't exist in the repository — referencing them creates broken, meaningless links.
+`.claude-work/` paths must never appear in commits, PRs, GitHub issues, or any output visible on GitHub. These files are local-only working documents that don't exist in the repository. Referencing them creates broken, meaningless links.
 
 ## What Does NOT Go in These Directories
 

--- a/skills/finish-issue/SKILL.md
+++ b/skills/finish-issue/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: finish-issue
 version: 2026.05.01@e2913b7
-description: Wrap up issue or side-quest work on the current issues/* or side-quest/* branch — run verification, check documentation needs, and generate PR description
+description: Wrap up issue or side-quest work on the current issues/* or side-quest/* branch. Runs verification, checks documentation needs, and generates a PR description
 argument-hint: [optional: issue-number-or-url] [--scratchpad]
 allowed-tools: Read, Write, Glob, Grep, AskUserQuestion, Bash(git branch --show-current), Bash(git status), Bash(git log *), Bash(git diff *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
 ---
 
 # Finish Issue
 
-Wraps up work on either an `issues/*` or `side-quest/*` branch — runs verification, checks documentation needs, and generates a PR description scratchpad.
+Wraps up work on either an `issues/*` or `side-quest/*` branch. Runs verification, checks documentation needs, and generates a PR description scratchpad.
 
 **Input:** $ARGUMENTS
 
@@ -43,20 +43,20 @@ Read the active-plan pointer written by `/start-issue` or `/start-side-quest` to
 - **Issue mode:** read `.claude-work/issues/<ID>/active-plan`
 - **Side-quest mode:** read `.claude-work/active-plan-<slug>`
 
-The pointer contents is a single project-root-relative path. Record it as the **resolved plan path** — this is the single source of truth for the primary plan.
+The pointer contents is a single project-root-relative path. Record it as the **resolved plan path**. This is the single source of truth for the primary plan.
 
-**If the pointer is missing:** proceed without a resolved plan — Step 4 context gathering falls back to git log and breadcrumbs only.
+**If the pointer is missing:** proceed without a resolved plan. Step 4 context gathering falls back to git log and breadcrumbs only.
 
 ## Step 2: Pre-PR Verification
 
 Run the project's standard verification commands from the project root:
 
-1. **Working document step check** — scan the resolved plan (note or scratchpad) for unfinished steps before running anything else
-2. **Format** — run the project's formatter (fix mode)
-3. **Tests** — run the full test suite; all must pass
-4. **Check status** — `git status` for uncommitted changes
+1. **Working document step check**: scan the resolved plan (note or scratchpad) for unfinished steps before running anything else
+2. **Format**: run the project's formatter (fix mode)
+3. **Tests**: run the full test suite; all must pass
+4. **Check status**: `git status` for uncommitted changes
 
-**Check 1 — Working document step check:** Read the resolved plan path (from Step 1b). If it points to a file containing a fenced JSON step block, collect all steps where `"status"` is `"pending"` or `"in_progress"`. If the resolved plan is a note (no JSON step block) or no plan was resolved, proceed silently — there's nothing structured to check.
+**Check 1. Working document step check:** Read the resolved plan path (from Step 1b). If it points to a file containing a fenced JSON step block, collect all steps where `"status"` is `"pending"` or `"in_progress"`. If the resolved plan is a note (no JSON step block) or no plan was resolved, proceed silently. There is nothing structured to check.
 
 If any unfinished steps are found, print a warning:
 
@@ -68,8 +68,8 @@ Warning: unfinished steps found in working document:
 
 Then use `AskUserQuestion` with two options:
 
-- **Proceed anyway** — continue to format, tests, and PR description generation
-- **Stop — I'll finish the steps first** — halt and print: "Stopping. Finish the outstanding steps, then re-run `/finish-issue`."
+- **Proceed anyway**: continue to format, tests, and PR description generation
+- **Stop: I'll finish the steps first**. halt and print: "Stopping. Finish the outstanding steps, then re-run `/finish-issue`."
 
 ```bash
 git status
@@ -113,9 +113,9 @@ Check if documentation updates are needed. Common touchpoints:
 Collect information from:
 
 - Commit history: read `Base branch:` from the resolved plan (recorded by `/start-issue` or `/start-side-quest`); fall back to `origin/main` if absent. Run: `git log --oneline <base-branch>..HEAD`
-- **Resolved plan** (from Step 1b) — read to extract the goal and rationale. This is the primary reference
-- Breadcrumbs (if exists) — incorporate highlights into the PR description; use the paths below based on mode
-- Auxiliary working documents — PR-comment responses, interim analysis notes. Globbed separately so multi-round PR feedback isn't lost. Use the paths below based on mode
+- **Resolved plan** (from Step 1b): read to extract the goal and rationale. This is the primary reference
+- Breadcrumbs (if exists): incorporate highlights into the PR description; use the paths below based on mode
+- Auxiliary working documents: PR-comment responses, interim analysis notes. Globbed separately so multi-round PR feedback isn't lost. Use the paths below based on mode
 
 **PR template detection:** Check the following locations in order and read the first file found:
 
@@ -123,7 +123,7 @@ Collect information from:
 2. `pull_request_template.md`
 3. `docs/pull_request_template.md`
 
-Note whether a template was found and its path — this is used in Step 5. If none of these files exist, proceed without a template. The `.github/PULL_REQUEST_TEMPLATE/` directory (multiple templates) is out of scope.
+Note whether a template was found and its path. This is used in Step 5. If none of these files exist, proceed without a template. The `.github/PULL_REQUEST_TEMPLATE/` directory (multiple templates) is out of scope.
 
 **Issue mode (path differences):**
 
@@ -141,14 +141,14 @@ Note whether a template was found and its path — this is used in Step 5. If no
 
 Choose the working-document type:
 
-- **Default (`/note`):** PR descriptions are pure prose — a note is the right fit
+- **Default (`/note`):** PR descriptions are pure prose. A note is the right fit
 - **Opt-in (`/scratchpad`):** triggered when `$ARGUMENTS` contains `--scratchpad` or when the user's invoking message contains a natural-language opt-in phrase
 
-**Issue mode** — use description: `finish-issue-<ID>`
+**Issue mode**: use description: `finish-issue-<ID>`
 
-**Side-quest mode** — use description: `finish-<slug>` (flat placement since side-quest branches don't match `issues/*`)
+**Side-quest mode**: use description: `finish-<slug>` (flat placement since side-quest branches don't match `issues/*`)
 
-**If a PR template was detected in Step 4:** use it as the structural base. Preserve its section headers and checkbox structure verbatim — only replace placeholder content with the actual information gathered (summary, changes, test plan, etc.). In issue mode, add a `Closes https://github.com/{owner}/{repo}/issues/{NUMBER}` line at the end if the template doesn't already include one. In side-quest mode, omit the Closes line.
+**If a PR template was detected in Step 4:** use it as the structural base. Preserve its section headers and checkbox structure verbatim. Only replace placeholder content with the actual information gathered (summary, changes, test plan, etc.). In issue mode, add a `Closes https://github.com/{owner}/{repo}/issues/{NUMBER}` line at the end if the template doesn't already include one. In side-quest mode, omit the Closes line.
 
 **If no PR template was found:** use the built-in template below.
 
@@ -164,7 +164,7 @@ Choose the working-document type:
 - Bulleted list of key changes
 - Omit file lists (PR shows modified files)
 - Group related changes
-- Documentation: CHANGELOG [added / not needed — reason]; README [updated / not needed — reason]
+- Documentation: CHANGELOG [added / not needed: reason]; README [updated / not needed: reason]
 
 ## Key Discoveries (if breadcrumbs exist)
 
@@ -190,6 +190,8 @@ If side-quest mode:
 
 Formatting: see `/prose-style` for hard-wrap, code-reference, and GitHub-reference rules.
 
+Before writing the PR description, skim the text for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.
+
 ## Step 6: Handle Ambiguity
 
 If unclear whether documentation is needed or other decisions arise:
@@ -214,7 +216,7 @@ Documentation:
 - README: [updated / not needed - reason]
 
 Files created:
-- <actual-path-to-pr-description> (PR description — note by default, scratchpad if --scratchpad)
+- <actual-path-to-pr-description> (PR description (note by default, scratchpad if --scratchpad))
 
 ---
 
@@ -239,7 +241,7 @@ Documentation:
 - README: [updated / not needed - reason]
 
 Files created:
-- <actual-path-to-pr-description> (PR description — note by default, scratchpad if --scratchpad)
+- <actual-path-to-pr-description> (PR description (note by default, scratchpad if --scratchpad))
 
 ---
 
@@ -263,8 +265,8 @@ Before finishing, verify:
 - [ ] Project's formatter ran successfully
 - [ ] Project's test suite passes
 - [ ] No uncommitted changes (or user has been notified)
-- [ ] Active-plan pointer resolved (or missing — Step 4 degrades to git log + breadcrumbs)
-- [ ] No pending/in-progress steps in the resolved plan (or user confirmed to proceed) — check skipped silently if the resolved plan is a note
+- [ ] Active-plan pointer resolved (or missing. Step 4 degrades to git log + breadcrumbs)
+- [ ] No pending/in-progress steps in the resolved plan (or user confirmed to proceed). Check skipped silently if the resolved plan is a note
 - [ ] PR description doesn't reference ephemeral files
 - [ ] Documentation needs have been assessed
 - [ ] Working document created with PR description (note by default, scratchpad if opted in)

--- a/skills/finish-issue/SKILL.md
+++ b/skills/finish-issue/SKILL.md
@@ -3,12 +3,12 @@ name: finish-issue
 version: 2026.05.01@e2913b7
 description: Wrap up issue or side-quest work on the current issues/* or side-quest/* branch. Runs verification, checks documentation needs, and generates a PR description
 argument-hint: [optional: issue-number-or-url] [--scratchpad]
-allowed-tools: Read, Write, Glob, Grep, AskUserQuestion, Bash(git branch --show-current), Bash(git status), Bash(git log *), Bash(git diff *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
+allowed-tools: Read, Write, Glob, Grep, AskUserQuestion, Bash(git branch --show-current), Bash(git status), Bash(git log *), Bash(git diff *), Bash(make lint-fix *), Bash(make test *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
 ---
 
 # Finish Issue
 
-Wraps up work on either an `issues/*` or `side-quest/*` branch. Runs verification, checks documentation needs, and generates a PR description scratchpad.
+Wraps up work on either an `issues/*` or `side-quest/*` branch. Runs verification, checks documentation needs, and generates a PR description (defaults to `/note`; use `--scratchpad` to produce a scratchpad).
 
 **Input:** $ARGUMENTS
 

--- a/skills/issue-context/SKILL.md
+++ b/skills/issue-context/SKILL.md
@@ -2,7 +2,7 @@
 name: issue-context
 version: 2026.05.01@e2913b7
 user-invocable: false
-description: Contract for target-path.sh — the shell script that resolves .claude-work/ file paths from the current git branch. Referenced by name from /scratchpad, /question, /commit-msg; not auto-consulted.
+description: Contract for target-path.sh, the shell script that resolves .claude-work/ file paths from the current git branch. Referenced by name from /scratchpad, /question, /commit-msg; not auto-consulted.
 allowed-tools: Bash(*/skills/issue-context/target-path.sh *)
 ---
 
@@ -27,4 +27,4 @@ The script reads the current branch, extracts the issue ID (numeric prefix of th
 
 ## History
 
-Before the refactor in [issues/120](https://github.com/couimet/my-claude-skills/issues/120), this file contained ~118 lines of Markdown that restated the branch-parsing rules in prose — and those same rules were also inlined into `/scratchpad`, `/question`, and `/commit-msg`. The audit concluded that deterministic logic belongs in a shell script (the pattern set by `/auto-number` and `/ensure-gitignore`), not in Markdown auto-consulted for every file-creation task. This file is now a pointer to the script.
+Before the refactor in [issues/120](https://github.com/couimet/my-claude-skills/issues/120), this file contained ~118 lines of Markdown that restated the branch-parsing rules in prose, and those same rules were also inlined into `/scratchpad`, `/question`, and `/commit-msg`. The audit concluded that deterministic logic belongs in a shell script (the pattern set by `/auto-number` and `/ensure-gitignore`), not in Markdown auto-consulted for every file-creation task. This file is now a pointer to the script.

--- a/skills/label-discovery/SKILL.md
+++ b/skills/label-discovery/SKILL.md
@@ -23,11 +23,11 @@ gh label list --repo owner/repo --json name,description --limit 200
 
 Classify into two groups:
 
-**GitHub defaults** — ship with every new repo, don't indicate structured usage:
+**GitHub defaults**: ship with every new repo, don't indicate structured usage:
 
 - bug, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix
 
-**Structured labels** — anything beyond the defaults. Their presence indicates intentional label conventions (e.g., `type:bug`, `priority:high`, `area:checkout`).
+**Structured labels**: anything beyond the defaults. Their presence indicates intentional label conventions (e.g., `type:bug`, `priority:high`, `area:checkout`).
 
 ## Prompt for Selection
 

--- a/skills/note/SKILL.md
+++ b/skills/note/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: note
 version: 2026.05.01@e2913b7
-description: Capture a quick note, finding, or result in a timestamped file under .claude-work/ — lightweight alternative to /scratchpad with no foundation skill dependencies
+description: Capture a quick note, finding, or result in a timestamped file under .claude-work/. Lightweight alternative to /scratchpad with no foundation skill dependencies
 argument-hint: <description>
 allowed-tools: Read, Write, Glob, Bash(git branch --show-current), Bash(mkdir -p *), Bash(date *)
 ---
@@ -14,7 +14,7 @@ Capture a note, finding, or result in a lightweight timestamped file. Use this i
 
 ## Step 1: Determine Target Directory and Timestamp
 
-Run both commands as parallel tool calls — they are independent:
+Run both commands as parallel tool calls. They are independent:
 
 ```bash
 git branch --show-current
@@ -47,11 +47,18 @@ Example: `20260329-143022-api-audit-findings.txt`
 
 ## Step 3: Write the File
 
-Write the note content to the file. The format is freeform — structure it however best fits the content being captured. There are no required sections or templates.
+Write the note content to the file. The format is freeform. Structure it however best fits the content being captured. There are no required sections or templates.
 
 **The one rule: each paragraph is ONE continuous line.** No line breaks at 72, 80, or any fixed column. Use line breaks only for structural separation (between paragraphs, around lists, around code blocks). Override your default instinct to wrap.
 
+### Output Anchors
+
+Format: freeform text.
+Length: unlimited.
+Perspective: whatever fits the content being captured.
+
 Before printing the path in Step 4, re-read the file and verify no paragraph contains a mid-sentence line break. Rewrite any that do.
+Also skim for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.
 
 ## Step 4: Confirm
 

--- a/skills/prose-style/SKILL.md
+++ b/skills/prose-style/SKILL.md
@@ -2,7 +2,7 @@
 name: prose-style
 version: 2026.05.01@e2913b7
 user-invocable: false
-description: Canonical prose and reference formatting rules for any skill that writes to a file — hard-wrap rule, code reference syntax, GitHub reference syntax. Auto-consulted whenever a skill produces file content.
+description: Canonical prose and reference formatting rules for any skill that writes to a file: hard-wrap rule, code reference syntax, GitHub reference syntax. Auto-consulted whenever a skill produces file content.
 allowed-tools: Bash(gh repo view *)
 ---
 
@@ -12,13 +12,19 @@ Single source of truth for how skill-generated text is written. Three rules, all
 
 ## Rule 1: Each paragraph is one continuous line
 
-**Write each paragraph as ONE continuous line, no matter how long.** Use line breaks for *structure* only — between paragraphs, before/after lists, between sections, around code blocks. Do NOT insert line breaks at 72, 80, or any fixed column to make the text "look nicer." Your default instinct will be to wrap; override it.
+**Write each paragraph as ONE continuous line, no matter how long.** Use line breaks for *structure* only: between paragraphs, before/after lists, between sections, around code blocks. Do NOT insert line breaks at 72, 80, or any fixed column to make the text "look nicer." Your default instinct will be to wrap; override it.
 
 This applies to every file a skill produces: scratchpads, questions, commit messages, PR descriptions, notes, breadcrumbs, CHANGELOG entries, article drafts.
+
+### Format Anchors
+
+Format: one continuous line per paragraph, no hard wrapping. Code references: path/to/file.ts#L10 (bare, never backtick-wrapped). GitHub references: full URL only.
 
 ### Self-check before you finish
 
 Before reporting a file path back to the user, re-read the file you just wrote. For each paragraph (text between blank lines, not inside a code block or table), verify it is a single continuous line. If you find any mid-sentence line break, rewrite that paragraph as one line. This check is cheap and catches the most common failure mode.
+
+Also skim for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.
 
 ## Rule 2: Code references
 
@@ -31,7 +37,7 @@ Use GitHub-style permalink syntax so references become clickable in RangeLink an
 | Char precision | `path/to/file.ts#L10C5-L20C15` | src/parser.ts#L42C3-L42C28 |
 
 - Workspace-relative paths only (never absolute).
-- Never wrap in backticks — the backticks become part of the parsed path and break navigation.
+- Write paths bare, without backticks. Backticks become part of the parsed path and break navigation.
 - Never use plain-text forms like "lines 26-37", "Line 539", or "(L42-L58)".
 
 ## Rule 3: GitHub references
@@ -56,4 +62,4 @@ Then append `/issues/{number}` or `/pull/{number}`.
 
 ## What this replaces
 
-Before 2026-04-20, the three rules above appeared as repeated epilogues in ~11 user-invocable skills, plus as separate `/code-ref` and `/github-ref` foundation skills. The audit at [issues/120](https://github.com/couimet/my-claude-skills/issues/120) consolidated everything here. Callers no longer need to repeat the rules — auto-consultation of `/prose-style` via this skill's description covers it.
+Callers no longer need to repeat the rules. Auto-consultation of `/prose-style` via this skill's description covers it.

--- a/skills/question/SKILL.md
+++ b/skills/question/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: question
 version: 2026.05.01@e2913b7
-description: Create a questions file in .claude-work/questions/ for gathering user input on design decisions. Questions go to file (never terminal) — user edits answers in-file as the single source of truth.
+description: Create a questions file in .claude-work/questions/ for gathering user input on design decisions. Questions go to file (never terminal). The user edits answers in-file as the single source of truth.
 argument-hint: <topic>
 allowed-tools: Read, Write, Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
 ---
@@ -14,7 +14,7 @@ Create a questions file in `.claude-work/` for gathering user input.
 
 ## Output format rule (read before writing anything)
 
-**Every paragraph in the questions file — Context, Options text, Recommendation reasoning, etc. — is ONE continuous line.** No line breaks at 72, 80, or any fixed column. Use line breaks only for structural separation: between questions, around the Options block, between fields. This overrides your default instinct to wrap long prose. See `/prose-style` for the full rationale.
+**Every paragraph in the questions file (Context, Options text, Recommendation reasoning, etc.) is ONE continuous line.** No line breaks at 72, 80, or any fixed column. Use line breaks only for structural separation: between questions, around the Options block, between fields. This overrides your default instinct to wrap long prose. See `/prose-style` for the full rationale.
 
 ## Core Principle
 
@@ -22,7 +22,7 @@ Questions are NEVER printed in terminal output. They go to a file that the user 
 
 ## Step 1: Resolve the Target Path
 
-Run these two commands as parallel tool calls — they are independent.
+Run these two commands as parallel tool calls. They are independent.
 
 ```bash
 ~/.claude/skills/issue-context/target-path.sh --type questions --description "$ARGUMENTS"
@@ -43,7 +43,7 @@ Files use `.txt` extension (not `.md`).
 
 ## Q001: <clear, specific question ending with ?>
 
-Context: <why this matters — what decision it unblocks>
+Context: <why this matters and what decision it unblocks>
 
 Options:
 A) <option> - <tradeoff or implication>
@@ -58,7 +58,7 @@ A001: [RECOMMENDED] A
 
 ## Q002: <clear, specific question ending with ?>
 
-Context: <why this matters — what decision it unblocks>
+Context: <why this matters and what decision it unblocks>
 Depends on: Q001 (explain how Q001's answer affects this question)
 
 Options:
@@ -76,12 +76,12 @@ A002: [RECOMMENDED] B
 
 Every question MUST include all fields in this order:
 
-1. **Heading**: `## QNNN:` — use `Q001`, `Q002`, etc. for easy cross-referencing
-2. **Context**: Why this matters — what decision it unblocks, what changes based on the answer
+1. **Heading**: `## QNNN:` use `Q001`, `Q002`, etc. for easy cross-referencing
+2. **Context**: Why this matters, what decision it unblocks, what changes based on the answer
 3. **Depends on** (optional): Reference earlier questions by ID when the answer affects this question (e.g., `Depends on: Q001`)
-4. **Options**: Labeled `A)`, `B)`, `C)` etc. — each with a concise tradeoff. Minimum 2, maximum 5.
+4. **Options**: Labeled `A)`, `B)`, `C)` etc., each with a concise tradeoff. Minimum 2, maximum 5.
 5. **Recommendation**: Your recommended option letter with brief reasoning
-6. **Answer**: `ANNN: [RECOMMENDED] <letter>` — prefilled with your recommendation
+6. **Answer**: `ANNN: [RECOMMENDED] <letter>`, prefilled with your recommendation
 
 ### Answer Acknowledgment
 
@@ -91,11 +91,11 @@ The `[RECOMMENDED]` marker signals this answer was prefilled by Claude and has n
 - **Acknowledged**: `A001: A` (user agreed with recommendation)
 - **Changed**: `A001: B; switched because...` (user chose differently)
 
-When reading answers back, treat any answer still containing `[RECOMMENDED]` as unacknowledged — do not proceed with those decisions without confirming.
+When reading answers back, treat any answer still containing `[RECOMMENDED]` as unacknowledged. Wait for the user to replace `[RECOMMENDED]` with their chosen letter before proceeding.
 
 ### Cross-Referencing
 
-Use `Q001`, `Q002` etc. to reference questions and `A001`, `A002` to reference answers — both within the questions file and from other documents (scratchpads, commit messages, etc.).
+Use `Q001`, `Q002` etc. to reference questions and `A001`, `A002` to reference answers, both within the questions file and from other documents (scratchpads, commit messages, etc.).
 
 ## Formatting
 
@@ -104,10 +104,10 @@ See `/prose-style` for hard-wrap and GitHub-reference rules.
 ## Process
 
 1. Create the file with questions formatted as above
-2. **Self-check for hard-wrapping.** Re-read the file. For each Context, Recommendation, and option description, verify the text is a single continuous line. If you find a mid-sentence line break in any of those fields, rewrite as one line. Do not skip this check.
-3. Print ONLY the filepath in terminal — nothing else
+2. **Self-check for hard-wrapping.** Re-read the file. For each Context, Recommendation, and option description, verify the text is a single continuous line. If you find a mid-sentence line break in any of those fields, rewrite as one line. Always complete this check. Also skim for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.
+3. Print ONLY the filepath in terminal. Nothing else.
 4. Wait for the user to edit answers in the file
-5. The file is the single source of truth — read it back to get answers
+5. The file is the single source of truth. Read it back to get answers
 
 ## When to Use
 

--- a/skills/scratchpad-ref-format/SKILL.md
+++ b/skills/scratchpad-ref-format/SKILL.md
@@ -2,7 +2,7 @@
 name: scratchpad-ref-format
 version: 2026.05.01@e2913b7
 user-invocable: false
-description: Defines the 4 invocation forms for referencing scratchpad steps — step-ID (#S), line-range (#L), space-separated, and bare-path auto-select. Auto-consulted by /tackle-scratchpad-block when parsing its argument.
+description: Defines the 4 invocation forms for referencing scratchpad steps: step-ID (#S), line-range (#L), space-separated, and bare-path auto-select. Auto-consulted by /tackle-scratchpad-block when parsing its argument.
 allowed-tools: Read
 ---
 
@@ -25,14 +25,14 @@ When invoking `/tackle-scratchpad-block`, the argument selects which step to exe
 
 **Line-range (`#L`):** Read those exact lines from the file. Power-user escape hatch for re-running or overriding a step.
 
-**Space-separated:** Equivalent to `#S` form — useful in environments where `#` in arguments is awkward. Match the trailing token (`S\d+`) to a step `"id"`.
+**Space-separated:** Equivalent to `#S` form, useful in environments where `#` in arguments is awkward. Match the trailing token (`S\d+`) to a step `"id"`.
 
 **Bare path (auto-select):** Read the full scratchpad, find all steps where `"status"` is `"pending"` and every entry in `"depends_on"` resolves to a step with `"status": "done"`.
 
 - One candidate: proceed with it.
-- Multiple candidates: list them and STOP — wait for the user to pick one.
+- Multiple candidates: list them and STOP. Wait for the user to pick one.
 - No candidates: report "All steps are done or blocked." and STOP.
 
 ## Error Handling
 
-If the reference doesn't resolve (file not found, step ID not in JSON, lines don't exist, or content isn't actionable steps): STOP immediately and report the issue. Do not guess, search for alternatives, or infer intent.
+If the reference doesn't resolve (file not found, step ID not in JSON, lines don't exist, or content isn't actionable steps): STOP immediately and report the issue. Report only the resolution failure with no fallback actions.

--- a/skills/scratchpad/SKILL.md
+++ b/skills/scratchpad/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scratchpad
 version: 2026.05.01@e2913b7
-description: Create an auto-numbered working document in .claude-work/scratchpads/ — implementation plans, PR descriptions, analysis notes, architecture decisions, issue drafts.
+description: Create an auto-numbered working document in .claude-work/scratchpads/: implementation plans, PR descriptions, analysis notes, architecture decisions, issue drafts.
 argument-hint: <description>
 allowed-tools: Read, Write, Glob, Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
 ---
@@ -16,9 +16,15 @@ Create or update a working document in `.claude-work/`.
 
 **Every paragraph in the scratchpad is ONE continuous line.** No line breaks at 72, 80, or any fixed column. Use line breaks only for structural separation: between paragraphs, before/after lists, around code blocks, between sections. This overrides your default instinct to wrap long prose. See `/prose-style` for the full rationale.
 
+### Output Anchors
+
+Length: varies by purpose and context.
+Format: freeform text with optional fenced JSON step block for implementation plans.
+Perspective: third-person technical.
+
 ## Step 1: Resolve the Target Path
 
-Run these two commands as parallel tool calls — they are independent.
+Run these two commands as parallel tool calls. They are independent.
 
 ```bash
 ~/.claude/skills/issue-context/target-path.sh --type scratchpads --description "$ARGUMENTS"
@@ -34,7 +40,7 @@ Use the stdout of the first command as the full file path. The script handles br
 
 Files use `.txt` extension (not `.md`).
 
-The content is freeform — structure it for the purpose at hand (plan, analysis, PR description, etc.).
+The content is freeform. Structure it for the purpose at hand (plan, analysis, PR description, etc.).
 
 ## Step Tracking
 
@@ -78,22 +84,24 @@ When a scratchpad contains an implementation plan, embed the steps inside a fenc
 
 Top-level fields (siblings of `steps`):
 
-- **`finish_issue_on_complete`** — Boolean, default `false` (omit to default). When `true`, `/tackle-scratchpad-block` invokes `/finish-issue` automatically after all steps reach `"done"`. Only `/start-issue` and `/start-side-quest` set this to `true` — they mark the scratchpad as the primary issue deliverable. Every other skill that creates scratchpads (ad-hoc `/scratchpad`, `/tackle-pr-comment`, CI fix scratchpads) omits it.
+- **`finish_issue_on_complete`**: Boolean, default `false` (omit to default). When `true`, `/tackle-scratchpad-block` invokes `/finish-issue` automatically after all steps reach `"done"`. Only `/start-issue` and `/start-side-quest` set this to `true`. They mark the scratchpad as the primary issue deliverable. Every other skill that creates scratchpads (ad-hoc `/scratchpad`, `/tackle-pr-comment`, CI fix scratchpads) omits it.
 
 Step-level fields (inside each `steps` entry):
 
-- **`id`** — `S001`, `S002`, etc. Zero-padded 3-digit IDs mirroring the `/question` skill's `Q001`/`A001` pattern. Use `S001` as the short form in cross-references.
-- **`title`** — Short description of the step.
-- **`status`** — `pending` | `in_progress` | `done` | `blocked`. Planning skills always write `"pending"`. Only `/tackle-scratchpad-block` transitions status during execution.
-- **`done_when`** — Concrete completion criteria. Recommended for implementation plans. Omit only for steps where completion is self-evident (e.g., "Delete file X"). A concrete criterion here helps `/tackle-scratchpad-block` confirm the step is truly done.
-- **`depends_on`** — Array of step IDs that must be `"done"` first. Empty array means no dependencies.
-- **`files`** — Array of file paths this step touches.
-- **`tasks`** — Array of concrete action items within the step.
-- **`addresses`** — (tackle-pr-comment only) Array of feedback item letters, e.g. `["A", "C"]`.
+- **`id`**: `S001`, `S002`, etc. Zero-padded 3-digit IDs mirroring the `/question` skill's `Q001`/`A001` pattern. Use `S001` as the short form in cross-references.
+- **`title`**: Short description of the step.
+- **`status`**: `pending` | `in_progress` | `done` | `blocked`. Planning skills always write `"pending"`. Only `/tackle-scratchpad-block` transitions status during execution.
+- **`done_when`**: Concrete completion criteria. Recommended for implementation plans. Omit only for steps where completion is self-evident (e.g., "Delete file X"). A concrete criterion here helps `/tackle-scratchpad-block` confirm the step is truly done.
+- **`depends_on`**: Array of step IDs that must be `"done"` first. Empty array means no dependencies.
+- **`files`**: Array of file paths this step touches.
+- **`tasks`**: Array of concrete action items within the step.
+- **`addresses`**: (tackle-pr-comment only) Array of feedback item letters, e.g. `["A", "C"]`.
 
 ## After writing: self-check for hard-wrapping
 
-Before reporting the filepath back to the user, re-read the scratchpad you just wrote. For each paragraph in the body (text between blank lines, outside code blocks, tables, and lists), verify it is a single continuous line. If you find a mid-sentence line break, rewrite that paragraph as one line. Do not skip this check — wrapped prose is the most common failure mode for skill-generated files.
+Before reporting the filepath back to the user, re-read the scratchpad you just wrote. For each paragraph in the body (text between blank lines, outside code blocks, tables, and lists), verify it is a single continuous line. If you find a mid-sentence line break, rewrite that paragraph as one line. Always complete this check. Wrapped prose is the most common failure mode for skill-generated files.
+
+Also skim for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.
 
 ## Formatting
 

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -8,19 +8,19 @@ allowed-tools: Read, Write, Glob, Grep, Bash(git fetch *), Bash(git checkout *),
 
 # Start Issue
 
-Analyze a GitHub issue, explore the codebase, and create a detailed implementation plan. This skill is for **planning only** — it does not implement anything.
+Analyze a GitHub issue, explore the codebase, and create a detailed implementation plan. This skill is for **planning only**. It does not implement anything.
 
 **Input:** $ARGUMENTS (a GitHub issue URL)
 
 ## Step 0: Clean Up Current Issue Artifacts
 
-Before starting new work, run `git branch --show-current` to detect whether the current branch is `issues/<ID>`. If so, extract the ID (numeric prefix before the first `-`/`_`, or the full segment after `issues/`) and use `Glob(pattern="*", path=".claude-work/issues/<ID>")` to check whether the issue's working directory has contents. If the directory exists and has files, invoke `/cleanup-issue` to offer cleanup of that specific directory. Other issue directories are left untouched — the user may return to them later.
+Before starting new work, run `git branch --show-current` to detect whether the current branch is `issues/<ID>`. If so, extract the ID (numeric prefix before the first `-`/`_`, or the full segment after `issues/`) and use `Glob(pattern="*", path=".claude-work/issues/<ID>")` to check whether the issue's working directory has contents. If the directory exists and has files, invoke `/cleanup-issue` to offer cleanup of that specific directory. Other issue directories are left untouched. The user may return to them later.
 
 **If no issue context on the current branch, or the directory doesn't exist or is empty:** proceed directly to Step 1.
 
 ## Step 1: Fetch Issue Details and Assign
 
-Run both commands as parallel tool calls in the same response — they are independent (one reads, one writes) and both use the input URL directly:
+Run both commands as parallel tool calls in the same response. They are independent (one reads, one writes) and both use the input URL directly:
 
 ```bash
 gh issue view $ARGUMENTS --json title,body,number,state,labels,assignees
@@ -30,7 +30,7 @@ gh issue view $ARGUMENTS --json title,body,number,state,labels,assignees
 gh issue edit $ARGUMENTS --add-assignee @me
 ```
 
-The assign is additive — existing assignees are preserved, not replaced. The command is idempotent (silently succeeds if you are already assigned).
+The assign is additive: existing assignees are preserved, not replaced. The command is idempotent (silently succeeds if you are already assigned).
 
 ## Step 2: Create Feature Branch
 
@@ -40,18 +40,18 @@ Create a feature branch from the selected base branch (`origin/main` by default,
 git fetch origin && git checkout -b issues/<NUMBER> <BASE_BRANCH>
 ```
 
-Where `<NUMBER>` is the GitHub issue number (e.g., `issues/223`) and `<BASE_BRANCH>` is typically `origin/main`. Record the actual base branch used in the scratchpad's `Base branch:` field — it may differ in stacked-PR workflows.
+Where `<NUMBER>` is the GitHub issue number (e.g., `issues/223`) and `<BASE_BRANCH>` is typically `origin/main`. Record the actual base branch used in the scratchpad's `Base branch:` field. It may differ in stacked-PR workflows.
 
 ## Step 3: Gather Full Context
 
-- **Fetch parent issues** — if the issue body references a parent (e.g., "Parent Issue: #47"), fetch it to understand the broader goal and how this issue fits into the plan
-- **Note child issues** — if this is a parent/epic, note child issues to understand full scope
-- **Explore the codebase** — use Grep/Glob/Read to find and examine:
+- **Fetch parent issues**: if the issue body references a parent (e.g., "Parent Issue: #47"), fetch it to understand the broader goal and how this issue fits into the plan
+- **Note child issues**: if this is a parent/epic, note child issues to understand full scope
+- **Explore the codebase**: use Grep/Glob/Read to find and examine:
   - Files/functions mentioned in the issue
   - Related code that will be affected
   - Existing patterns to follow
   - Test files that will need updates
-- **Check integration points** — review the project's entry points, configuration, documentation, and discoverability conventions for anything the change might affect
+- **Check integration points**: review the project's entry points, configuration, documentation, and discoverability conventions for anything the change might affect
 
 ## Step 4: Create Implementation Plan Working Document
 
@@ -60,14 +60,14 @@ Choose the working-document type based on whether formal step tracking is reques
 - **Default (`/note`):** use this unless the user explicitly opted in. Produces a lightweight, freeform plan. Relies on you (the LLM) to self-organize execution in-session via TaskCreate/TaskUpdate.
 - **Opt-in (`/scratchpad`):** triggered when `$ARGUMENTS` contains `--scratchpad`, or when the user's invoking message contains a natural-language opt-in phrase ("use a scratchpad", "with step tracking", "formal plan", "track steps"). Produces a scratchpad with a JSON step block so `/tackle-scratchpad-block` can drive execution.
 
-### 4a. Default path — `/note`
+### 4a. Default path: `/note`
 
-Use `/note` with description `start-issue-plan`. The note MUST contain these sections (all prose — no JSON step block):
+Use `/note` with description `start-issue-plan`. The note MUST contain these sections (all prose, no JSON step block):
 
 ````markdown
 # Issue #NUMBER: Title
 
-Base branch: <branch this was cut from — origin/main, or another branch if instructed>
+Base branch: <branch this was cut from (origin/main, or another branch if instructed)>
 Parent: https://github.com/{owner}/{repo}/issues/{XX} (omit if no parent)
 
 ## Context
@@ -77,16 +77,16 @@ Parent: https://github.com/{owner}/{repo}/issues/{XX} (omit if no parent)
 
 ## Assumptions Made (omit section if none)
 
-- "Assuming X because Y" — non-obvious reasoning only
+- "Assuming X because Y": non-obvious reasoning only
 
 ## Plan
 
 Numbered prose steps (no fenced JSON). Each step should be commit-sized, specific (name files/functions), ordered (dependencies clear), and mention test updates where relevant.
 ````
 
-### 4b. Opt-in path — `/scratchpad`
+### 4b. Opt-in path: `/scratchpad`
 
-Use `/scratchpad` with description `start-issue-plan`. The scratchpad uses the same prose sections as 4a, except the `## Plan` section is replaced with `## Implementation Plan` containing a fenced JSON step block. See the `/scratchpad` Step Tracking section for the full schema. For `/start-issue` specifically: set `finish_issue_on_complete: true` at the top level, and always set each step's `status: "pending"` when planning — `/tackle-scratchpad-block` manages status transitions during execution.
+Use `/scratchpad` with description `start-issue-plan`. The scratchpad uses the same prose sections as 4a, except the `## Plan` section is replaced with `## Implementation Plan` containing a fenced JSON step block. See the `/scratchpad` Step Tracking section for the full schema. For `/start-issue` specifically: set `finish_issue_on_complete: true` at the top level, and always set each step's `status: "pending"` when planning. `/tackle-scratchpad-block` manages status transitions during execution.
 
 ### 4c. Write the active-plan pointer
 
@@ -100,7 +100,7 @@ After the working document is created (via either path), write the pointer file 
 .claude-work/issues/126/notes/20260424-143022-start-issue-plan.txt
 ```
 
-Overwrite any existing pointer — only the most recent working document is "active".
+Overwrite any existing pointer. Only the most recent working document is "active".
 
 Formatting: see `/prose-style` for hard-wrap, code-reference, and GitHub-reference rules.
 
@@ -131,7 +131,7 @@ Print the branch name, the working-document path, the active-plan pointer path, 
 ```text
 Next: review the plan, then ask me to proceed with the first step (e.g. "start S1" or just "go ahead").
 I will self-organize execution using the note as reference.
-Commit model: one commit at the end covering all changes. When done, call /finish-issue directly —
+Commit model: one commit at the end covering all changes. When done, call /finish-issue directly.
 do NOT call /commit-msg first. The PR description file doubles as the commit message body.
 ```
 
@@ -157,7 +157,7 @@ This skill is for planning only. After reporting status:
 Before finishing, verify:
 
 - [ ] Feature branch `issues/<NUMBER>` was created
-- [ ] Working document created via `/note` (default) or `/scratchpad` (opt-in) — not both
+- [ ] Working document created via `/note` (default) or `/scratchpad` (opt-in), not both
 - [ ] `.claude-work/issues/<NUMBER>/active-plan` pointer written with the project-root-relative path to the working document
 - [ ] Plan has specific file/function names (not "update the code")
 - [ ] Each step is small enough to be one commit
@@ -165,3 +165,4 @@ Before finishing, verify:
 - [ ] Assumptions are documented with reasoning
 - [ ] Questions (if any) would genuinely change the plan if answered differently
 - [ ] Documentation and discoverability considered
+- [ ] Also skim for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -3,7 +3,7 @@ name: start-issue
 version: 2026.05.01@e2913b7
 description: Start working on a GitHub issue - analyze, explore codebase, and create detailed implementation plan
 argument-hint: <github-issue-url> [--scratchpad]
-allowed-tools: Read, Write, Glob, Grep, Bash(git fetch *), Bash(git checkout *), Bash(gh issue view *), Bash(gh issue edit * --add-assignee *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
+allowed-tools: Read, Write, Glob, Grep, Bash(git branch --show-current), Bash(git fetch *), Bash(git checkout *), Bash(gh issue view *), Bash(gh issue edit * --add-assignee *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
 ---
 
 # Start Issue

--- a/skills/start-side-quest/SKILL.md
+++ b/skills/start-side-quest/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Read, Write, Glob, Grep, Bash(git fetch *), Bash(git checkout *),
 
 # Start Side-Quest
 
-Start a "side-quest" — a focused branch for orthogonal improvements discovered while working on another issue. Side-quests keep the main issue branch clean and focused.
+Start a "side-quest": a focused branch for orthogonal improvements discovered while working on another issue. Side-quests keep the main issue branch clean and focused.
 
 **Input:** $ARGUMENTS
 
@@ -40,7 +40,7 @@ git stash push -m "WIP: <parent-branch> - paused for side-quest"
 
 Derive a slug from the description (lowercase, hyphens, no special chars).
 
-The base branch for the side-quest is the branch that was active when `/start-side-quest` was invoked (captured in Step 1). This is typically `origin/main` but may be any branch — for example, when working in a stack of PRs.
+The base branch for the side-quest is the branch that was active when `/start-side-quest` was invoked (captured in Step 1). This is typically `origin/main` but may be any branch, for example, when working in a stack of PRs.
 
 ```bash
 git fetch origin
@@ -64,14 +64,14 @@ Choose the working-document type based on whether formal step tracking is reques
 
 Side-quest branches don't match `issues/*`, so the working document lands in the flat `.claude-work/notes/` (default) or `.claude-work/scratchpads/` (opt-in) directory.
 
-### 3a. Default path — `/note`
+### 3a. Default path: `/note`
 
-Use `/note` with description `side-quest-<slug>`. The note MUST contain (all prose — no JSON step block):
+Use `/note` with description `side-quest-<slug>`. The note MUST contain (all prose, no JSON step block):
 
 ````markdown
 # Side-Quest: <Title>
 
-Base branch: <branch this was cut from — origin/main, issues/XXX, or another branch>
+Base branch: <branch this was cut from (origin/main, issues/XXX, or another branch)>
 
 ## Goal
 
@@ -82,7 +82,7 @@ Base branch: <branch this was cut from — origin/main, issues/XXX, or another b
 Numbered prose steps (no fenced JSON). Each step commit-sized and specific.
 ````
 
-### 3b. Opt-in path — `/scratchpad`
+### 3b. Opt-in path: `/scratchpad`
 
 Use `/scratchpad` with description `side-quest-<slug>`. Same sections as 3a, except `## Plan` is replaced with `## Implementation Plan` containing a fenced JSON step block per the `/scratchpad` Step Tracking schema. Set `finish_issue_on_complete: true` at the top level.
 
@@ -119,7 +119,7 @@ Branch: side-quest/<slug>
 Parent: <original branch> (stashed if had changes)
 
 Files created:
-- .claude-work/notes/<file>.txt (implementation plan — default path)
+- .claude-work/notes/<file>.txt (implementation plan, default path)
   OR .claude-work/scratchpads/<file>.txt (if --scratchpad)
 - .claude-work/active-plan-<slug> (pointer to the working document)
 - .claude-work/questions/<file>.txt (if questions needed)
@@ -148,7 +148,7 @@ Before finishing, verify:
 
 - [ ] Current work stashed (if on a work branch with changes)
 - [ ] Side-quest branch created from `<base-branch>`
-- [ ] Working document created via `/note` (default) or `/scratchpad` (opt-in) — not both
+- [ ] Working document created via `/note` (default) or `/scratchpad` (opt-in). Not both
 - [ ] `.claude-work/active-plan-<slug>` pointer written with the project-root-relative path to the working document
 - [ ] Plan has specific file/change details
 - [ ] Parent branch noted for easy return

--- a/skills/tackle-pr-comment/SKILL.md
+++ b/skills/tackle-pr-comment/SKILL.md
@@ -8,11 +8,11 @@ allowed-tools: Read, Glob, Grep, Write, Bash(gh api repos/*/*/pulls/*/reviews/*)
 
 # Tackle PR Comment
 
-Analyze a PR comment, explore the referenced code, and create a detailed implementation working document. This skill is for **analysis and planning only** — it does not implement changes until the user approves.
+Analyze a PR comment, explore the referenced code, and create a detailed implementation working document. This skill is for **analysis and planning only**. It does not implement changes until the user approves.
 
 **Input:** $ARGUMENTS (a PR comment URL, optionally followed by `--scratchpad`)
 
-This skill produces an *auxiliary* working document — it does NOT overwrite the branch's active-plan pointer. `/finish-issue` will still treat the primary plan (from the original `/start-issue` or `/start-side-quest`) as the reference; this document is read as supplementary context.
+This skill produces an *auxiliary* working document. It does NOT overwrite the branch's active-plan pointer. `/finish-issue` will still treat the primary plan (from the original `/start-issue` or `/start-side-quest`) as the reference; this document is read as supplementary context.
 
 ## Step 1: Parse the URL and Fetch the Comment
 
@@ -96,9 +96,9 @@ Where:
 
 **Naming convention:** use letters (A, B, C) for feedback items in text headings. When the opt-in path applies, use `S001`, `S002` IDs for implementation steps in the JSON block. This avoids confusion when referencing "Feedback B" vs "S002".
 
-### 5a. Default path — `/note`
+### 5a. Default path: `/note`
 
-Use `/note` with the description above. The note contains (all prose — no JSON step block):
+Use `/note` with the description above. The note contains (all prose, no JSON step block):
 
 ````markdown
 # PR https://github.com/{owner}/{repo}/pull/{PR_NUMBER} Comment Response
@@ -112,21 +112,21 @@ Source: {FULL_PR_COMMENT_URL}
 {Analysis of first feedback item}
 
 Decision: ACCEPT | IGNORE
-Reason: {brief justification — omit if self-evident from the analysis above}
+Reason: {brief justification. Omit if self-evident from the analysis above}
 
 ### Feedback B: {short title}
 
 {Analysis of second feedback item}
 
 Decision: ACCEPT | IGNORE
-Reason: {brief justification — omit if self-evident from the analysis above}
+Reason: {brief justification. Omit if self-evident from the analysis above}
 
 ## Action Plan
 
 Numbered prose steps (no fenced JSON). Each step names the feedback items it addresses (e.g. "Step 1 (addresses A, C): ...") and the specific files/functions to change. Feedback items marked IGNORE do not appear here.
 ````
 
-### 5b. Opt-in path — `/scratchpad`
+### 5b. Opt-in path: `/scratchpad`
 
 Use `/scratchpad` with the description above. Same sections as 5a, except `## Action Plan` is replaced with `## Implementation Plan` containing a fenced JSON step block per the `/scratchpad` Step Tracking schema. For PR-comment work:
 
@@ -169,7 +169,7 @@ When the user approves the plan and asks to proceed:
 3. **If any reviewer feedback was ignored**: Add an `Ignored Feedback:` section after the Benefits section. For each ignored item:
    - Briefly describe the suggestion that was not implemented
    - Include reasoning for why it was skipped (prefilled based on your recommendation if the user didn't provide explicit reasoning)
-   - This ensures reviewers know the feedback wasn't missed—it was intentionally declined
+   - This ensures reviewers know the feedback wasn't missed. It was intentionally declined
 
 4. **Then**: Proceed with implementation.
 
@@ -198,7 +198,7 @@ Before finishing initial analysis (Step 7):
 
 - [ ] Comment was fetched successfully with full thread context (if applicable)
 - [ ] Working document (note or scratchpad) contains link to source PR comment
-- [ ] Working document created via `/note` (default) or `/scratchpad` (opt-in) — not both
+- [ ] Working document created via `/note` (default) or `/scratchpad` (opt-in). Not both
 - [ ] Active-plan pointer was NOT overwritten (PR-comment scratchpads are auxiliary)
 - [ ] Plan has specific file/function names
 - [ ] Each step is actionable and concrete

--- a/skills/tackle-scratchpad-block/SKILL.md
+++ b/skills/tackle-scratchpad-block/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tackle-scratchpad-block
 version: 2026.05.01@e2913b7
-description: Execute a single step from a scratchpad plan — transitions status, runs tests, creates a commit message. Main execution engine for /start-issue → /finish-issue.
+description: Execute a single step from a scratchpad plan. Transitions status, runs tests, creates a commit message. Main execution engine for /start-issue → /finish-issue.
 argument-hint: <path/to/scratchpad.txt [#S00N | S00N | #L10-L20]>
 allowed-tools: Read, Write, Edit, Bash(*), Glob, Grep
 ---
@@ -18,7 +18,7 @@ Execute a specific block of implementation steps from a scratchpad file, then cr
 
 Determine the file the user's argument points at (the path portion before `#S00N` or `#L10-L20`) and check whether it contains a fenced JSON step block (look for ` ```json ` with a `"steps"` array).
 
-**If the argument resolves to a file containing a JSON step block:** proceed normally to Step 1. The explicit argument always takes precedence — the active-plan pointer is not consulted.
+**If the argument resolves to a file containing a JSON step block:** proceed normally to Step 1. The explicit argument always takes precedence. The active-plan pointer is not consulted.
 
 **If the argument does NOT resolve to a JSON step block** (file not found, or file exists but has no `"steps"` array): read the active-plan pointer (issue mode: `.claude-work/issues/<ID>/active-plan`; side-quest mode: `.claude-work/active-plan-<slug>`) to name the resolved path in the guidance message; if the pointer file is missing or empty, use `(no active-plan pointer found)` as the resolved path. Then STOP:
 
@@ -26,7 +26,7 @@ Determine the file the user's argument points at (the path portion before `#S00N
 This skill drives execution against a JSON step block, but the working document at
 <resolved-path> is a note (no step block found).
 
-You are in the default note-based workflow — the LLM self-organizes execution using
+You are in the default note-based workflow. The LLM self-organizes execution using
 in-session task tracking. To proceed, choose one of:
 
   A. Re-run the start-phase skill with --scratchpad to produce a scratchpad instead:
@@ -36,16 +36,16 @@ in-session task tracking. To proceed, choose one of:
   B. Pass an explicit scratchpad path if you have one:
        /tackle-scratchpad-block path/to/plan.txt#S001
 
-  C. Proceed manually — ask Claude to implement the next step from the note directly.
+  C. Proceed manually: ask Claude to implement the next step from the note directly.
 
-When done with implementation, call /finish-issue directly — do NOT call /commit-msg first.
+When done with implementation, call /finish-issue directly. Do NOT call /commit-msg first.
 ```
 
 ## Step 1: Read the Target Block
 
 Parse the argument using the rules defined in `/scratchpad-ref-format`, then locate the target step.
 
-**If the reference doesn't resolve** (file not found, step ID not in JSON, lines don't exist, or content isn't actionable steps): STOP immediately and report the issue. Do not attempt to guess, search for alternatives, or infer intent.
+**If the reference doesn't resolve** (file not found, step ID not in JSON, lines don't exist, or content isn't actionable steps): STOP immediately and report the issue. Report only the resolution failure with no fallback actions.
 
 ### Check Step Status
 
@@ -64,7 +64,7 @@ Read the full scratchpad to understand:
 - Parent issue context (if noted)
 - Files to modify (from "Files to Modify" section if present)
 
-**Done-step collapsing:** For any non-target step in the JSON block whose `"status"` is `"done"`, only note its `id`, `title`, and `status` — discard its `done_when`, `depends_on`, `files`, and `tasks`. Exception: if the selected step itself has `"status": "done"` and the user confirmed re-execution (Step 1), keep its full contents in context so its `tasks` and `files` remain actionable. Collapsing non-target done steps keeps the working context lean as the plan progresses.
+**Done-step collapsing:** For any non-target step in the JSON block whose `"status"` is `"done"`, only note its `id`, `title`, and `status`. Discard its `done_when`, `depends_on`, `files`, and `tasks`. Exception: if the selected step itself has `"status": "done"` and the user confirmed re-execution (Step 1), keep its full contents in context so its `tasks` and `files` remain actionable. Collapsing non-target done steps keeps the working context lean as the plan progresses.
 
 Note: User controls execution order. Do not verify or block based on previous steps.
 
@@ -114,7 +114,7 @@ After successful execution and passing tests, update the step's status in the sc
 
 Use the Edit tool to replace `"status": "in_progress"` with `"status": "done"`. Include the `"id"` and `"title"` fields in the old_string for Edit uniqueness.
 
-**If tests fail or execution is incomplete**, leave the step as `"in_progress"` — do NOT mark it `"done"`.
+**If tests fail or execution is incomplete**, leave the step as `"in_progress"`. Do NOT mark it `"done"`.
 
 ### Completion Check
 
@@ -130,15 +130,15 @@ Count the total number of steps in the `"steps"` array (regardless of status) to
 Create a `/commit-msg` file for this step first (as described below), then invoke `/finish-issue`. Print:
 
 ```text
-All steps complete (finish_issue_on_complete: true) — invoking /finish-issue
+All steps complete (finish_issue_on_complete: true). Invoking /finish-issue
 ```
 
 **If both conditions are true AND the scratchpad has exactly one step:**
 
-Invoke `/finish-issue` directly — no commit message file needed. Print:
+Invoke `/finish-issue` directly. No commit message file needed. Print:
 
 ```text
-All steps complete (finish_issue_on_complete: true) — invoking /finish-issue
+All steps complete (finish_issue_on_complete: true). Invoking /finish-issue
 ```
 
 **Otherwise** (any step still pending/in_progress/blocked, OR the field is absent or false): create a commit message file as below.
@@ -161,7 +161,7 @@ Print:
 3. Test results (pass/fail count)
 4. Either:
    - **All steps done + `finish_issue_on_complete: true` + multi-step scratchpad:** Commit message file path, then PR description path from `/finish-issue`
-   - **All steps done + `finish_issue_on_complete: true` + single-step scratchpad:** `/finish-issue` was invoked — no commit message file
+   - **All steps done + `finish_issue_on_complete: true` + single-step scratchpad:** `/finish-issue` was invoked. No commit message file
    - **Otherwise:** Commit message file path
 
 **IMPORTANT: Do NOT run `git commit`.**


### PR DESCRIPTION
## Summary

Applied LinkedIn-post prompt-optimization advice across all 20 skills. Replaced em dashes with standard punctuation, rephrased negative instructions positively where it improves clarity, added explicit Length/Format/Tone output anchors to text-producing skills, and upgraded self-checks to catch common AI-writing patterns. All changes are cosmetic prose improvements — no behavioral changes to skill execution.

## Changes

- Replaced all em dashes across 20 SKILL.md files (~200 instances) with periods, colons, or commas, matching the context of each use
- Rephrased 8 negative instructions to positive form (e.g., "do not skip this check" → "Always complete this check"; "Do not attempt to guess" → "Report only the resolution failure with no fallback actions")
- Added explicit LinkedIn-style output anchors (Length/Format/Tone/Perspective) to commit-msg, scratchpad, note, prose-style, and question
- Upgraded self-checks in all 7 text-producing skills to also skim for AI-writing tells: em dashes, filler phrases, vague attributions, generic positive conclusions
- Documentation: CHANGELOG added; README not needed (internal prose improvements)

## Test Plan

- [x] All 149 existing tests pass
- [x] markdownlint: 0 errors across 58 files
- [x] Manual verification: grep confirms zero em dashes remaining across all SKILL.md files

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `/ensure-gitignore` to consistently target the repository root `.gitignore` instead of resolving relative to the current directory.

* **Documentation**
  * Enhanced guidance across all 20 skills with clearer instructions, refined wording, and improved examples for better clarity and consistency.

* **Chores**
  * Added changelog entry for version 2026.05.15.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/my-claude-skills/pull/137)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->