### PR TITLE
[issues/138] Second pass on LinkedIn-post prompt-optimization advice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.05.21
+
+### Changed
+
+- Second pass of LinkedIn-post prompt-optimization advice across `/start-issue`, `/tackle-pr-comment`, `/finish-issue`, and `/tackle-scratchpad-block`: added Output Anchors blocks to the prose-producing skills, a rules-restate-and-re-read prelude to the executor skills, and a one-line reasoning push at the point each skill writes prose. Also rewrote four remaining negative imperatives to positive form ([issues/138](https://github.com/couimet/my-claude-skills/issues/138))
+
 ## 2026.05.15
 
 ### Changed

--- a/skills/auto-number/SKILL.md
+++ b/skills/auto-number/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(*/skills/auto-number/auto-number.sh *)
 
 # Auto-Number
 
-Returns the next available sequence number for files in a directory. Run the script and use its stdout directly -- do not reimplement the numbering logic.
+Returns the next available sequence number for files in a directory. Run the script and use its stdout directly. The script is the single source of truth for the numbering logic.
 
 ## Usage
 

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -177,7 +177,7 @@ These rules ensure entries describe what users experience, not how the code work
 
 ## Implementation-Detail Blocklist
 
-Flag entries containing these patterns. Warn but do not block. Rare edge cases may legitimately include a technical name.
+Flag entries containing these patterns. Emit a warning and allow the entry. Rare edge cases may legitimately include a technical name.
 
 | Pattern | Why it's flagged |
 | --- | --- |

--- a/skills/finish-issue/SKILL.md
+++ b/skills/finish-issue/SKILL.md
@@ -190,6 +190,14 @@ If side-quest mode:
 
 Formatting: see `/prose-style` for hard-wrap, code-reference, and GitHub-reference rules.
 
+### Output Anchors
+
+Deliverable: a single text file whose first line is the PR title and whose remaining lines are the PR description body. Both are consumed downstream: `gh pr create --title "<first line>" --body-file <path>` reads them from one file.
+Length: title under 70 characters, formatted `[<branch-name>] Short summary`. Body: 2 to 3 sentences in Summary; 3 to 8 bullets in Changes; 2 to 5 checkboxes in Test Plan. Whole document fits on one screen unless the branch is unusually large.
+Format: line 1 is the title. Line 2 is blank. The remaining lines are the body, following the PR template sections in order (Summary, Changes, Key Discoveries, Test Plan, Related). If a repository template was detected in Step 4, follow that template's body structure instead and preserve its headers verbatim. The title-on-line-1 convention is independent of the template.
+Scope: changes that shipped on this branch only. Document future work, alternatives considered, and abandoned approaches elsewhere.
+Tone: direct, why-focused, reviewer-facing. Avoid restating the diff.
+
 Before writing the PR description, skim the text for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.
 
 ## Step 6: Handle Ambiguity

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -55,6 +55,8 @@ Where `<NUMBER>` is the GitHub issue number (e.g., `issues/223`) and `<BASE_BRAN
 
 ## Step 4: Create Implementation Plan Working Document
 
+Before drafting the plan, re-read the issue body, any parent issue, and the files surfaced in Step 3. Think through actual file and function names, step ordering, and dependencies before writing. The plan is the highest-leverage artifact this skill produces. Treat it as such.
+
 Choose the working-document type based on whether formal step tracking is requested:
 
 - **Default (`/note`):** use this unless the user explicitly opted in. Produces a lightweight, freeform plan. Relies on you (the LLM) to self-organize execution in-session via TaskCreate/TaskUpdate.
@@ -103,6 +105,14 @@ After the working document is created (via either path), write the pointer file 
 Overwrite any existing pointer. Only the most recent working document is "active".
 
 Formatting: see `/prose-style` for hard-wrap, code-reference, and GitHub-reference rules.
+
+### Output Anchors
+
+Deliverable: implementation plan note (or scratchpad, if opted in).
+Length: as long as needed to name specific files and functions. Sections are typically 1 to 4 short paragraphs. The Plan list contains however many commit-sized steps the work actually requires. A trivial fix may be one step; a large refactor may be a dozen or more. Match the issue, not a number.
+Format: prose sections (Context, Assumptions Made, Plan) per the template above. No fenced JSON in the default `/note` path.
+Scope: planning only. Name files, functions, and test updates. Skip implementation prose.
+Tone: direct, concrete, file-and-function-named. No hedging, no generic conclusions.
 
 ## Step 5: Create Questions File (Only If Necessary)
 

--- a/skills/tackle-pr-comment/SKILL.md
+++ b/skills/tackle-pr-comment/SKILL.md
@@ -82,6 +82,8 @@ Before creating the scratchpad, assess if the feedback is clear enough to act on
 
 ## Step 5: Create Implementation Working Document
 
+Before drafting, restate the rules that apply to this document: hard-wrap and reference rules from `/prose-style`, and the Output Anchors block below. Then re-read the comment thread, the linked code, and any files explored in Step 3. Decide ACCEPT or IGNORE on each feedback item with the actual code in mind. The analysis is the highest-leverage artifact this skill produces.
+
 Choose the working-document type based on whether formal step tracking is requested:
 
 - **Default (`/note`):** use this unless the user explicitly opted in. Produces a lightweight, freeform analysis + action plan.
@@ -123,7 +125,7 @@ Reason: {brief justification. Omit if self-evident from the analysis above}
 
 ## Action Plan
 
-Numbered prose steps (no fenced JSON). Each step names the feedback items it addresses (e.g. "Step 1 (addresses A, C): ...") and the specific files/functions to change. Feedback items marked IGNORE do not appear here.
+Numbered prose steps (no fenced JSON). Each step names the feedback items it addresses (e.g. "Step 1 (addresses A, C): ...") and the specific files/functions to change. Feedback items marked IGNORE are omitted from this list.
 ````
 
 ### 5b. Opt-in path: `/scratchpad`
@@ -135,7 +137,15 @@ Use `/scratchpad` with the description above. Same sections as 5a, except `## Ac
 
 Formatting: see `/prose-style` for hard-wrap, code-reference, and GitHub-reference rules.
 
-**STOP HERE** - The template ends above. Do NOT add commit message sections to the working document. Commit messages are created separately in Step 8 (after user approval) using `/commit-msg`.
+### Output Anchors
+
+Deliverable: a single text file containing the analysis of each feedback item and the action plan.
+Length: 1 to 2 sentences per feedback item under Analysis. The user will ask for more depth or clarification if needed. Action Plan is however many steps the work actually requires. A single sentence is enough for a trivial change; multi-feedback responses may need several steps. Each step names the feedback letters it addresses.
+Format: prose sections (Analysis with per-item Decision + Reason, Action Plan) per the template above. No fenced JSON in the default `/note` path.
+Scope: this comment thread's feedback only. Leave broader refactors and out-of-scope improvements out of the Action Plan.
+Tone: direct, decision-first (ACCEPT or IGNORE), reviewer-facing.
+
+**STOP HERE** - The template ends above. Always end the working document at this point. Commit messages are created separately in Step 8 (after user approval) using `/commit-msg`.
 
 ## Step 6: Questions (If Needed)
 

--- a/skills/tackle-scratchpad-block/SKILL.md
+++ b/skills/tackle-scratchpad-block/SKILL.md
@@ -78,7 +78,9 @@ Before executing, assess if the steps are clear enough:
 
 ## Step 4: Mark In-Progress and Execute
 
-Before executing, update the step's status in the scratchpad's JSON block:
+Before executing, restate the rules that govern this step: the rules from `/prose-style` for any prose this step writes, and any skill-specific output anchors that apply (e.g. `/commit-msg` anchors when the step will produce a commit message). Then re-read the full step block, its `done_when` criteria, and any cross-referenced files. Think about the actual change before writing any code or running any commands.
+
+Update the step's status in the scratchpad's JSON block:
 
 ```json
 "id": "S002",


### PR DESCRIPTION
## Summary

PR #137 already absorbed one LinkedIn post on prompt anatomy by applying it across all 20 skills (em dashes, positive phrasing, output anchors, anti-AI self-checks). Issue #138 lists five more LinkedIn posts and asks how to apply them. Most overlap with what #137 shipped. This PR acts on the four genuine deltas.

## Changes

- Added explicit Output Anchors blocks (Deliverable / Length / Format / Scope / Tone) to the three skills that produce original prose and lacked them: `/start-issue` (Step 4), `/tackle-pr-comment` (Step 5), `/finish-issue` (Step 5).
- Added a "restate the rules and re-read the inputs before acting" prelude to the two executor skills: `/tackle-scratchpad-block` (Step 4) and `/tackle-pr-comment` (Step 5). The prelude forces explicit retrieval of the relevant `/prose-style` rules and any skill-specific anchors before the skill produces output.
- Added a one-line reasoning push at the point where each of `/start-issue`, `/tackle-pr-comment`, and `/tackle-scratchpad-block` produces prose. Framed positively ("re-read the inputs, think before drafting") rather than as a generic "go beyond basics" push.
- Rewrote four imperative negative phrasings missed by PR #137 to positive form: `/auto-number` ("do not reimplement" → "The script is the single source of truth"), `/changelog` ("do not block" → "allow the entry"), `/finish-issue` ("do not belong here" → "Document elsewhere"), `/tackle-pr-comment` ("do not appear here" → "are omitted").
- Documentation: CHANGELOG entry added under `2026.05.21`. README not needed (internal prose improvements, no new commands or settings).

## Key Discoveries

- The five LinkedIn posts cluster into themes that PR #137 already covered. The honest finding was that most of the value had been captured; the new deltas were narrow.
- The "list relevant rules first" tip and the "go beyond basics" tip are distinct techniques (forced retrieval versus deliberation push). They can sit adjacent in the same step block without redundancy, as long as each says something concrete.
- `/note` is now the choke point for plan and analysis prose since #126 made it the default. The reasoning push still belongs on the trigger skills that drive `/note`, not on `/note` itself. `/note` is a "brain file" telling Claude how to write a note, not where the deliberation happens.

## Test Plan

- [x] All 149 existing tests pass (`make test`)
- [x] markdownlint clean across 121 files (`make lint`)
- [x] Manual: re-grep for `do not|don't|never|avoid` confirms only descriptive uses remain (safety properties like "never truncates", "never absolute", "never backtick-wrapped")

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/138
- Builds on https://github.com/couimet/my-claude-skills/pull/137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added "Output Anchors" sections across multiple skills specifying expected deliverables and format constraints
  * Introduced pre-execution thinking reminders and re-read checkpoints to improve task clarity
  * Enhanced prompt guidance with improved instruction phrasing and better structured rules
  * Updated skill descriptions for clearer understanding of scope and expected outputs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/my-claude-skills/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->