### PR TITLE
[issues/142] Update README for `/note` default; preserve `/scratchpad` demo

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,2 +1,3 @@
 ignores:
   - "demo/**"
+  - ".history/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Contributors are encouraged to add a changelog entry with their PR, but it's not
 ### Fixed
 
 - CodeRabbit badge in README header. Stripped the custom styling params that were keeping shields.io stuck on a cached "provider or repo not found" response.
+- `make lint` now ignores `.history/**` (IDE backup snapshots), matching the existing `demo/**` ignore.
 
 ## 2026.05.21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Contributors are encouraged to add a changelog entry with their PR, but it's not
 
 - README "See It In Action" section now leads with the current `/note`-based default flow and a refreshed mermaid diagram. The original `/scratchpad`-based walkthrough is preserved verbatim inside a collapsed `<details>` memorabilia block alongside the existing demo. Quick Start was re-ordered to introduce `/note` first, then `/scratchpad`, matching the May 2026 migration. CLAUDE.md's issue workflow description was updated to describe the note default with the scratchpad opt-in. An "Update" blockquote at the top of `demo/real-life/issues-10/TIMELINE.md` now signals that the demo predates the migration and links to the article ([issues/142](https://github.com/couimet/my-claude-skills/issues/142))
 
+### Fixed
+
+- CodeRabbit badge in README header. Stripped the custom styling params that were keeping shields.io stuck on a cached "provider or repo not found" response.
+
 ## 2026.05.21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.05.26
+
+### Changed
+
+- README "See It In Action" section now leads with the current `/note`-based default flow and a refreshed mermaid diagram. The original `/scratchpad`-based walkthrough is preserved verbatim inside a collapsed `<details>` memorabilia block alongside the existing demo. Quick Start was re-ordered to introduce `/note` first, then `/scratchpad`, matching the May 2026 migration. CLAUDE.md's issue workflow description was updated to describe the note default with the scratchpad opt-in. An "Update" blockquote at the top of `demo/real-life/issues-10/TIMELINE.md` now signals that the demo predates the migration and links to the article ([issues/142](https://github.com/couimet/my-claude-skills/issues/142))
+
 ## 2026.05.21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
-## 2026.05.26
+## 2026.05.25
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance for AI agents working inside the `my-claude-skills` 
 
 ## Project Purpose
 
-This repository is a collection of portable Claude Code skills. Each skill is a `SKILL.md` file inside a `skills/<name>/` directory. Skills are installed globally at `~/.claude/skills/` (via symlinks) and loaded by Claude Code when a user types `/skill-name`. The repo's goal is to encode repeatable workflows — issue triage, PR feedback, scratchpad-driven implementation — as portable, composable instructions.
+This repository is a collection of portable Claude Code skills. Each skill is a `SKILL.md` file inside a `skills/<name>/` directory. Skills are installed globally at `~/.claude/skills/` (via symlinks) and loaded by Claude Code when a user types `/skill-name`. The repo's goal is to encode repeatable workflows — issue triage, PR feedback, plan-driven implementation — as portable, composable instructions.
 
 ## Development Commands
 
@@ -60,9 +60,9 @@ Skills reference each other using `/skill-name` syntax in prose (e.g., "Use `/sc
 
 Work on GitHub issues follows this chain:
 
-1. `/start-issue <url>` — fetches the issue, creates an `issues/<NUMBER>` branch, explores the codebase, and writes an implementation plan scratchpad
-2. `/tackle-scratchpad-block <path>` — executes one step from the scratchpad, runs tests, creates a commit message file
-3. `/finish-issue` — runs verification (lint, tests), checks documentation needs, generates a PR description scratchpad
+1. `/start-issue <url>` — fetches the issue, creates an `issues/<NUMBER>` branch, explores the codebase, and writes an implementation plan as a `/note` (or as a `/scratchpad` with `--scratchpad` opt-in for formal step tracking)
+2. **Execute the plan.** On the default note path, Claude self-organizes execution in-session from the note (one commit at the end). On the opt-in scratchpad path, run `/tackle-scratchpad-block <path>` once per step — each call runs tests and creates a commit message file
+3. `/finish-issue` — runs verification (lint, tests), checks documentation needs, and generates a PR description note
 
 ### Rules
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a collection of portable [Claude Code skills](https://code.claude.com/do
 > **Want to see these skills in action?** Read the [full follow-along](https://ouimet.info/follow-alongs/my-claude-skills-issues-10.html) — a real issue turned into a shipped PR, with every artifact visible.
 
 [![Follow-along](https://img.shields.io/badge/Follow--along-See%20it%20in%20action-blue)](https://ouimet.info/follow-alongs/my-claude-skills-issues-10.html)
-![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/couimet/my-claude-skills?utm_source=oss&utm_medium=github&utm_campaign=couimet%2Fmy-claude-skills&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/couimet/my-claude-skills?label=CodeRabbit+Reviews)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -30,13 +30,34 @@ The install script is idempotent — safe to run on every pull. It only creates/
 
 Once installed, try these in any project:
 
-### `/scratchpad` — Create a working document
+### `/note` — Capture a quick note, finding, or plan
+
+```text
+/note api audit findings
+```
+
+Creates a `.claude-work/notes/20260521-143022-api-audit-findings.txt` file — a timestamped, freeform capture for findings, quick plans, or anything else worth writing down.
+
+<details>
+<summary>What a note looks like</summary>
+
+```text
+# API audit findings
+
+The `/v2/orders` endpoint accepts a `limit` query parameter but silently caps it at 50 regardless of the value passed. Caller code in `services/sync/poll.ts` assumes the cap is 100, which means the sync loop has been processing in half-size batches for months without anyone noticing.
+
+Two things to fix: (1) document the real cap in the OpenAPI schema, (2) widen the cap to 100 to match the original intent (no DB cost concerns since 100 still fits in one page).
+```
+
+</details>
+
+### `/scratchpad` — Create a working document with step tracking
 
 ```text
 /scratchpad plan the authentication refactor
 ```
 
-Creates a `.claude-work/scratchpads/0001-plan-the-authentication-refactor.txt` file with structured step tracking. The file is git-ignored — it's your private workspace.
+Creates a `.claude-work/scratchpads/0001-plan-the-authentication-refactor.txt` file. Like `/note` but with a structured JSON step block at the bottom: each step has a status (`pending` → `in_progress` → `done`), a `done_when` criterion, and a dependency list. Reach for this when work breaks down naturally into commit-sized steps and you want to land them one at a time. Larger issues, parallel worktrees, and anything where formal status transitions help you stay oriented are the typical uses.
 
 <details>
 <summary>See a real scratchpad from this repo</summary>
@@ -128,22 +149,41 @@ All working files live under `.claude-work/` and are git-ignored automatically. 
 
 ## See It In Action
 
-These skills aren't meant to be used in isolation — they compose into a full issue lifecycle. Here's the flow:
+These skills compose into a full issue lifecycle. The default flow today: `/start-issue` writes a `/note` plan, Claude self-organizes execution in-session, `/finish-issue` wraps up with a PR description that doubles as the commit message body. When work warrants formal step tracking (typically larger issues where you want a commit per step), opt in with `--scratchpad` and Claude drives execution through `/tackle-scratchpad-block`. The May 2026 migration that introduced this default is covered in [I sold you on /scratchpad. Then I migrated to /note.](https://dev.to/couimet/i-sold-you-on-scratchpad-then-i-migrated-to-note-4n1o).
 
 ```mermaid
-graph LR
-    A["/start-issue"] --> B["/tackle-scratchpad-block"]
-    B --> C{More steps?}
-    C -- yes --> B
-    C -- no --> D["/finish-issue"]
-    B -.-> E["/breadcrumb"]
-    B -.-> F["/start-side-quest"]
-    B -.-> G["/question"]
-    B -.-> I["/create-github-issue"]
-    B -.-> J["/note"]
-    F --> B
-    D -.-> H["/cleanup-issue"]
+flowchart TD
+    A[GitHub Issue] --> B["/start-issue"]
+    B --> C{"Working document<br/>type?"}
+    C -->|default| D["/note"]
+    C -->|"--scratchpad opt-in"| E["/scratchpad"]
+
+    subgraph EX ["Execution"]
+        F["Claude self-organizes<br/>in one session"]
+        G["/tackle-scratchpad-block<br/>one or more steps per invocation"]
+    end
+
+    D --> F
+    E --> G
+    F --> H["/finish-issue"]
+    G --> H
+    H --> I["PR description<br/>(doubles as commit message)"]
+    H -.-> J["/cleanup-issue"]
+
+    EX -.-> K["/breadcrumb"]
+    EX -.-> L["/start-side-quest"]
+    EX -.-> M["/question"]
+    EX -.-> N["/create-github-issue"]
+    L -.-> EX
+
+    classDef secondary stroke-dasharray:5 5
+    class E,G secondary
 ```
+
+For a real end-to-end walkthrough — the workflow that produced this very README, captured artifact-by-artifact — open the memorabilia below.
+
+<details>
+<summary><strong>Memorabilia: the original <code>/scratchpad</code> walkthrough that built this README (replaced by <code>/note</code> in May 2026)</strong></summary>
 
 Every artifact linked below is real — generated while building the README you're reading right now ([issue #10](https://github.com/couimet/my-claude-skills/issues/10)). The full unredacted history lives in [`demo/real-life/issues-10/`](demo/real-life/issues-10/).
 
@@ -277,6 +317,8 @@ Scratchpad drafted during implementation → real GitHub issue, labels applied, 
 ### Following along
 
 The [`demo/real-life/issues-10/`](demo/real-life/issues-10/) folder contains every artifact from this issue's lifecycle — scratchpads, questions, commit messages, and README snapshots — numbered chronologically. [`TIMELINE.md`](demo/real-life/issues-10/TIMELINE.md) provides the narrative context for each one.
+
+</details>
 
 ## Featured In
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ All working files live under `.claude-work/` and are git-ignored automatically. 
 
 ## See It In Action
 
-These skills compose into a full issue lifecycle. The default flow today: `/start-issue` writes a `/note` plan, Claude self-organizes execution in-session, `/finish-issue` wraps up with a PR description that doubles as the commit message body. When work warrants formal step tracking (typically larger issues where you want a commit per step), opt in with `--scratchpad` and Claude drives execution through `/tackle-scratchpad-block`. The May 2026 migration that introduced this default is covered in [I sold you on /scratchpad. Then I migrated to /note.](https://dev.to/couimet/i-sold-you-on-scratchpad-then-i-migrated-to-note-4n1o).
+These skills compose into a full issue lifecycle. The default flow today: `/start-issue` writes a `/note` plan, Claude self-organizes execution in-session, `/finish-issue` generates a PR description note that you reuse as the commit message body when you commit manually. When work warrants formal step tracking (typically larger issues where you want a commit per step), opt in with `--scratchpad` and Claude drives execution through `/tackle-scratchpad-block`. The May 2026 migration that introduced this default is covered in [I sold you on /scratchpad. Then I migrated to /note.](https://dev.to/couimet/i-sold-you-on-scratchpad-then-i-migrated-to-note-4n1o).
 
 ```mermaid
 flowchart TD

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ All working files live under `.claude-work/` and are git-ignored automatically. 
 
 ## See It In Action
 
-These skills compose into a full issue lifecycle. The default flow today: `/start-issue` writes a `/note` plan, Claude self-organizes execution in-session, `/finish-issue` generates a PR description note that you reuse as the commit message body when you commit manually. When work warrants formal step tracking (typically larger issues where you want a commit per step), opt in with `--scratchpad` and Claude drives execution through `/tackle-scratchpad-block`. The May 2026 migration that introduced this default is covered in [I sold you on /scratchpad. Then I migrated to /note.](https://dev.to/couimet/i-sold-you-on-scratchpad-then-i-migrated-to-note-4n1o).
+These skills compose into a full issue lifecycle. The default flow today: `/start-issue` writes a `/note` plan, Claude self-organizes execution in-session, `/finish-issue` generates a PR description note that you reuse as the commit message body when you commit manually. When work warrants formal step tracking (typically larger issues where you want a commit per step), opt in with `--scratchpad` and Claude drives execution through `/tackle-scratchpad-block`. The May 2026 migration that introduced this default is covered in [I sold you on /scratchpad. Then I migrated to /note.](https://dev.to/couimet/i-sold-you-on-scratchpad-then-i-migrated-to-note-4n1o) article.
 
 ```mermaid
 flowchart TD

--- a/demo/real-life/issues-10/TIMELINE.md
+++ b/demo/real-life/issues-10/TIMELINE.md
@@ -4,6 +4,8 @@ This is a real, unredacted record of how Claude Code skills were used to plan an
 
 Every numbered file in this folder has a corresponding entry here. Read the folder listing top-to-bottom for the chronological story; read this file for the narrative context behind each artifact.
 
+> **Update (2026-05-21):** the workflow captured below predates the May 2026 `/note` migration. `/start-issue` and the other composite skills now default to producing a `/note` instead of a `/scratchpad`, and Claude self-organizes execution rather than going through `/tackle-scratchpad-block` per step. The original `/scratchpad`-based loop is still available as an opt-in via `--scratchpad`. The reasoning is in [I sold you on /scratchpad. Then I migrated to /note.](https://dev.to/couimet/i-sold-you-on-scratchpad-then-i-migrated-to-note-4n1o). This demo stays preserved as a complete record of the original flow.
+
 ---
 
 ## Phase 1: Pre-Planning (before any branch or formal /start-issue)


### PR DESCRIPTION
## Summary

The README's "See It In Action" section described the original `/scratchpad` + `/tackle-scratchpad-block` loop as if it were current, but the May 2026 migration made `/note` the default. This refreshes the visible walkthrough (intro, mermaid, Quick Start ordering) to match the current default flow and preserves the original `/scratchpad` walkthrough verbatim inside a collapsed memorabilia `<details>` block, so the deep-link `#see-it-in-action` that has been circulated externally stays accurate without losing the historical record.

## Changes

- README.md "See It In Action": new `flowchart TD` mermaid with `/note` and `/scratchpad` branching out of a `Working document type?` decision and merging back into an `Execution` subgraph (so the dotted satellites `/breadcrumb`, `/start-side-quest`, `/question`, `/create-github-issue` attach to the subgraph and visually apply to both execution paths). `/cleanup-issue` hangs off `/finish-issue`. Rewritten intro paragraph naming the default flow and the opt-in path. Inline pointer to the dev.to migration article. The prior walkthrough (six numbered subsections plus "Following along") moved verbatim into a `<details>` block with summary "Memorabilia: the original `/scratchpad` walkthrough that built this README (replaced by `/note` in May 2026)".
- README.md Quick Start re-ordered to lead with `/note`. The `/note` subsection describes the tool by what it is (a timestamped, freeform capture for findings or quick plans), with an example block showing one in practice. The `/scratchpad` subsection now anchors against `/note` ("Like `/note` but with a structured JSON step block...") and names the mechanics concretely (status flow, `done_when`, dependency list, when to reach for it). `/question` and `/commit-msg` subsections unchanged.
- CLAUDE.md issue-workflow description (Step 1-3) rewritten to describe the note default with the scratchpad opt-in. Project-purpose phrasing softened from "scratchpad-driven implementation" to "plan-driven implementation" since both working-document types are now legitimate.
- demo/real-life/issues-10/TIMELINE.md: "Update (2026-05-21)" blockquote added near the top, modeled on the same convention already used in `media/2026-03-devto-post-vide-coding.md` line 9 and `media/2026-04-devto-post-audit-pivot.md` line 9. Tells visitors that the demo predates the `/note` migration and links to the article so they know we keep iterating.
- Documentation: CHANGELOG entry added under `## 2026.05.26` (`### Changed`). README updated as the primary deliverable. CLAUDE.md updated alongside.

## Test Plan

- [x] `make lint && make test` (markdownlint-cli2 0 errors; 149 bats tests pass)
- [ ] Eyeball the new mermaid on GitHub once the PR is open. The `subgraph EX ["Execution"]` wrapper, the `EX -.-> satellite` edges, and the `classDef secondary` dashed styling on the scratchpad path all rely on GitHub's mermaid renderer honoring the syntax cleanly. If subgraph-to-node edge routing looks off, fall back to attaching satellites to both F and G individually.
- [ ] Open `https://github.com/couimet/my-claude-skills#see-it-in-action` from the branch to confirm the anchor still resolves and the memorabilia `<details>` block collapses by default.

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/142
- Builds on the May 2026 `/note` migration shipped under [issues/139](https://github.com/couimet/my-claude-skills/issues/139) and described in [I sold you on /scratchpad. Then I migrated to /note.](https://dev.to/couimet/i-sold-you-on-scratchpad-then-i-migrated-to-note-4n1o)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow documentation to reflect `/note` as the default execution path for GitHub issues.
  * Expanded issue lifecycle guidance with refreshed diagrams and workflow descriptions.
  * Added documentation for the `/note` command with examples.
  * Preserved original workflow documentation in collapsible sections for historical reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/my-claude-skills/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->