### PR TITLE
[issues/146] Fetch issue comments in `/start-issue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.06.05
+
+### Fixed
+
+- `/start-issue` now fetches issue comments alongside the body and explicitly instructs the LLM to read every comment before planning. Previously, `gh issue view` omitted `comments` from its JSON fields entirely, so any CodeRabbit analysis or follow-up discussion added after the original description was invisible when the plan was formed ([issues/146](https://github.com/couimet/my-claude-skills/issues/146))
+
 ## 2026.05.25
 
 ### Changed

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -23,7 +23,7 @@ Before starting new work, run `git branch --show-current` to detect whether the 
 Run both commands as parallel tool calls in the same response. They are independent (one reads, one writes) and both use the input URL directly:
 
 ```bash
-gh issue view $ARGUMENTS --json title,body,number,state,labels,assignees
+gh issue view $ARGUMENTS --json title,body,number,state,labels,assignees,comments
 ```
 
 ```bash
@@ -31,6 +31,8 @@ gh issue edit $ARGUMENTS --add-assignee @me
 ```
 
 The assign is additive: existing assignees are preserved, not replaced. The command is idempotent (silently succeeds if you are already assigned).
+
+**Read all comments before continuing.** If the `comments` array is non-empty, read every comment in full — treat them as equal-weight context alongside the issue body. Design discussions, CodeRabbit analysis, and follow-up decisions in comments often refine or contradict the original description.
 
 ## Step 2: Create Feature Branch
 


### PR DESCRIPTION
## Summary

`/start-issue` was silently dropping all issue comments because `gh issue view` was called without `comments` in its JSON fields. Any CodeRabbit analysis or follow-up discussion added after the original description was invisible when the LLM formed its plan. This change fetches comments and adds an explicit instruction to read them before proceeding.

## Changes

- `skills/start-issue/SKILL.md`: added `comments` to the `gh issue view --json` fields in Step 1 (root cause fix)
- `skills/start-issue/SKILL.md`: added a bold reading instruction after the Step 1 assign note, telling the LLM to read all comments as equal-weight context before planning
- `CHANGELOG.md`: Fixed entry added for 2026.06.05

## Test Plan

- [x] All existing tests pass (149/149)
- [x] `make lint` clean

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `/start-issue` to include issue comments alongside the issue body when planning, ensuring complete discussion context is available for comprehensive analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->