### PR TITLE
[issues/148] Fix target-path.sh to anchor paths to repo root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.06.05.1
+
+### Fixed
+
+- `target-path.sh` now anchors all directory operations to the git repo root via `git rev-parse --show-toplevel`, so running a skill from a subdirectory no longer creates a rogue `.claude-work/` tree at the wrong level. Added a bats test covering the subdirectory-CWD scenario ([issues/148](https://github.com/couimet/my-claude-skills/issues/148))
+
 ## 2026.06.05
 
 ### Fixed

--- a/skills/issue-context/target-path.sh
+++ b/skills/issue-context/target-path.sh
@@ -128,6 +128,10 @@ if [[ "$branch" == issues/* ]]; then
   fi
 fi
 
+# --- Anchor to repo root so all paths are resolved relative to it, not CWD ---
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+[ -n "$repo_root" ] && cd "$repo_root"
+
 # --- Determine target directory ---
 if [ -n "$issue_id" ]; then
   target_dir=".claude-work/issues/${issue_id}/${type_arg}"

--- a/tests/target-path.bats
+++ b/tests/target-path.bats
@@ -217,3 +217,17 @@ teardown() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"T002"* ]]
 }
+
+# ============================================================================
+# Repo-root anchoring: output is relative to repo root, not CWD
+# ============================================================================
+
+@test "subdirectory CWD: output path is relative to repo root, not CWD" {
+  mkdir -p subdir
+  cd subdir
+  run "$SCRIPT" --type notes --description "from subdir"
+  [ "$status" -eq 0 ]
+  [ "$output" = ".claude-work/notes/0001-from-subdir.txt" ]
+  [ -d "$TEST_TEMP_DIR/.claude-work/notes" ]
+  [ ! -d "$TEST_TEMP_DIR/subdir/.claude-work" ]
+}


### PR DESCRIPTION
## Summary

`target-path.sh` built its output path relative to CWD, so running any skill that writes a working file from a subdirectory would silently create a `.claude-work/` tree at the wrong level. The fix adds a `cd "$(git rev-parse --show-toplevel)"` anchor after branch detection, making all path operations relative to the repo root regardless of where the caller is standing.

## Changes

- `skills/issue-context/target-path.sh`: `cd` to repo root after branch detection so `auto-number.sh --mkdir` and the output path are anchored to the git root, not CWD
- `tests/target-path.bats`: new test (ok 131) — cds into a subdirectory and asserts the output path is repo-root-relative and the directory is NOT created inside the subdirectory
- `CHANGELOG.md`: Fixed entry added under `## 2026.06.05.1`

## Test Plan

- [x] All 150 tests pass (149 existing + 1 new)
- [x] New test: `subdirectory CWD: output path is relative to repo root, not CWD`
- [x] `make lint` clean

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the `.claude-work/` directory was created at incorrect levels when running the script from a subdirectory; now correctly anchors all operations to the repository root.
  * Added test coverage for subdirectory execution scenarios to prevent regression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->