### PR TITLE
[issues/147] Add `/pre-write` to prevent thought-process leakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.06.07
+
+### Added
+
+- New `/pre-write` foundation skill defines the think-before-writing rule: complete all reasoning before producing any file content. Content-generating skills (`/note`, `/scratchpad`, `/question`, `/commit-msg`, `/finish-issue`, `/start-issue`) now reference it, preventing in-progress deliberation from leaking into generated files. Documented in `README.md` and `skills/README.md`. ([issues/147](https://github.com/couimet/my-claude-skills/issues/147))
+
 ## 2026.06.05.1
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ These skills aren't invoked directly — Claude consults them when the context m
 | `file-placement` | When deciding where to put a new file — routes to the right directory |
 | `github-ref` | When skill-generated text contains issue or PR references — requires full GitHub URLs, never short-form `#NNN` or `PR #NNN` |
 | `label-discovery` | When `/create-github-issue` needs labels — fetches repo labels, classifies as defaults vs structured, and prompts the user |
+| `pre-write` | Before any skill writes file content — requires complete reasoning before writing the first word, preventing in-progress deliberation from appearing in generated files |
 | `issue-context` | When on an `issues/<N>` branch — scopes working files to issue subdirectories |
 | `scratchpad-ref-format` | When `/tackle-scratchpad-block` parses its argument — defines the 4 invocation forms (`#S`, `#L`, space-separated, bare-path auto-select) |
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -21,6 +21,7 @@ Non-invocable skills (`user-invocable: false`) don't appear in the `/` menu. The
 | --- | --- |
 | `/file-placement` | Decision tree for where to put different file types. Claude auto-consults when deciding output locations. |
 | `/label-discovery` | Fetches GitHub labels, classifies them as defaults vs structured, and prompts the user for selection. Auto-consulted by `/create-github-issue`. |
+| `/pre-write` | Think-before-writing rule for content-generating skills. Requires complete reasoning before writing the first word — no mid-stream self-corrections in generated files. Auto-consulted before any skill writes file content. |
 | `/prose-style` | Canonical prose and reference formatting rules — hard-wrap rule, code-reference syntax, GitHub-reference syntax. Auto-consulted whenever a skill produces file content. |
 | `/scratchpad-ref-format` | Defines the 4 invocation forms for referencing scratchpad steps (`#S`, `#L`, space-separated, bare-path auto-select). Auto-consulted by `/tackle-scratchpad-block` when parsing its argument. |
 

--- a/skills/commit-msg/SKILL.md
+++ b/skills/commit-msg/SKILL.md
@@ -14,6 +14,8 @@ Create a commit message file in `.claude-work/`. You write the message, the user
 
 ## Output format rule (read before writing anything)
 
+See `/pre-write` for the think-before-writing rule: complete all reasoning before writing the first word.
+
 **Every paragraph in the body is ONE continuous line.** No line breaks at 72, 80, or any fixed column. Use line breaks only for structural separation: between paragraphs, before/after the Benefits list, around code blocks. This overrides your default instinct to wrap long prose. See `/prose-style` for the full rationale.
 
 ## Core Principle

--- a/skills/finish-issue/SKILL.md
+++ b/skills/finish-issue/SKILL.md
@@ -139,6 +139,8 @@ Note whether a template was found and its path. This is used in Step 5. If none 
 
 ## Step 5: Generate PR Description Working Document
 
+See `/pre-write` for the think-before-writing rule: complete all reasoning before writing the first word.
+
 Choose the working-document type:
 
 - **Default (`/note`):** PR descriptions are pure prose. A note is the right fit

--- a/skills/note/SKILL.md
+++ b/skills/note/SKILL.md
@@ -47,6 +47,8 @@ Example: `20260329-143022-api-audit-findings.txt`
 
 ## Step 3: Write the File
 
+See `/pre-write` for the think-before-writing rule: complete all reasoning before writing the first word.
+
 Write the note content to the file. The format is freeform. Structure it however best fits the content being captured. There are no required sections or templates.
 
 **The one rule: each paragraph is ONE continuous line.** No line breaks at 72, 80, or any fixed column. Use line breaks only for structural separation (between paragraphs, around lists, around code blocks). Override your default instinct to wrap.

--- a/skills/pre-write/SKILL.md
+++ b/skills/pre-write/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: pre-write
+version: 0.0.0@000000
+description: Think-before-writing rule for content-generating skills. Complete all reasoning before producing any file content. Auto-consulted before any skill writes file content.
+user-invocable: false
+allowed-tools:
+---
+
+# Pre-Write
+
+**Consulted automatically by content-generating skills. Not invoked directly by the user.**
+
+## Think before writing
+
+Complete all context-gathering and reasoning before producing any file content. The file must reflect finished thinking, not in-progress deliberation.
+
+Phrases like "oh wait," "I now realize," "actually," "hmm," or any mid-stream self-correction in a generated file are signals that writing started too early. They must not appear in generated files.
+
+If context is incomplete — or if a decision would benefit from user input — stop and use `/question` before proceeding. Never embed uncertainty or evolving reasoning in the generated file.
+
+The test: can you state the full shape of the output before writing the first word? If not, gather more context first.

--- a/skills/question/SKILL.md
+++ b/skills/question/SKILL.md
@@ -14,6 +14,8 @@ Create a questions file in `.claude-work/` for gathering user input.
 
 ## Output format rule (read before writing anything)
 
+See `/pre-write` for the think-before-writing rule: complete all reasoning before writing the first word.
+
 **Every paragraph in the questions file (Context, Options text, Recommendation reasoning, etc.) is ONE continuous line.** No line breaks at 72, 80, or any fixed column. Use line breaks only for structural separation: between questions, around the Options block, between fields. This overrides your default instinct to wrap long prose. See `/prose-style` for the full rationale.
 
 ## Core Principle

--- a/skills/scratchpad/SKILL.md
+++ b/skills/scratchpad/SKILL.md
@@ -14,6 +14,8 @@ Create or update a working document in `.claude-work/`.
 
 ## Output format rule (read before writing anything)
 
+See `/pre-write` for the think-before-writing rule: complete all reasoning before writing the first word.
+
 **Every paragraph in the scratchpad is ONE continuous line.** No line breaks at 72, 80, or any fixed column. Use line breaks only for structural separation: between paragraphs, before/after lists, around code blocks, between sections. This overrides your default instinct to wrap long prose. See `/prose-style` for the full rationale.
 
 ### Output Anchors

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -57,7 +57,7 @@ Where `<NUMBER>` is the GitHub issue number (e.g., `issues/223`) and `<BASE_BRAN
 
 ## Step 4: Create Implementation Plan Working Document
 
-Before drafting the plan, re-read the issue body, any parent issue, and the files surfaced in Step 3. Think through actual file and function names, step ordering, and dependencies before writing. The plan is the highest-leverage artifact this skill produces. Treat it as such.
+Before drafting the plan, re-read the issue body, any parent issue, and the files surfaced in Step 3. Think through actual file and function names, step ordering, and dependencies before writing. The plan is the highest-leverage artifact this skill produces. Treat it as such. See `/pre-write` for the think-before-writing rule. If any aspect of the plan is unclear after this review, use `/question` before writing.
 
 Choose the working-document type based on whether formal step tracking is requested:
 

--- a/tests/pre-write.bats
+++ b/tests/pre-write.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+SKILL="$PROJECT_ROOT/skills/pre-write/SKILL.md"
+
+# =============================================================
+# Front matter
+# =============================================================
+
+@test "pre-write skill: file exists" {
+  [ -f "$SKILL" ]
+}
+
+@test "pre-write skill: has name field" {
+  grep -q "^name: pre-write$" "$SKILL"
+}
+
+@test "pre-write skill: is a foundation skill (user-invocable: false)" {
+  grep -q "user-invocable: false" "$SKILL"
+}
+
+@test "pre-write skill: has description field" {
+  grep -q "^description:" "$SKILL"
+}
+
+# =============================================================
+# Content: rule correctness
+# =============================================================
+
+@test "pre-write skill: mentions /question as escape hatch" {
+  grep -q "/question" "$SKILL"
+}
+
+@test "pre-write skill: names at least one forbidden phrase" {
+  grep -qE '"oh wait"|"I now realize"|self-correction' "$SKILL"
+}
+
+# =============================================================
+# References in content-generating skills
+# =============================================================
+
+@test "note skill: references /pre-write" {
+  grep -q "/pre-write" "$PROJECT_ROOT/skills/note/SKILL.md"
+}
+
+@test "scratchpad skill: references /pre-write" {
+  grep -q "/pre-write" "$PROJECT_ROOT/skills/scratchpad/SKILL.md"
+}
+
+@test "question skill: references /pre-write" {
+  grep -q "/pre-write" "$PROJECT_ROOT/skills/question/SKILL.md"
+}
+
+@test "commit-msg skill: references /pre-write" {
+  grep -q "/pre-write" "$PROJECT_ROOT/skills/commit-msg/SKILL.md"
+}
+
+@test "finish-issue skill: references /pre-write" {
+  grep -q "/pre-write" "$PROJECT_ROOT/skills/finish-issue/SKILL.md"
+}
+
+@test "start-issue skill: references /pre-write" {
+  grep -q "/pre-write" "$PROJECT_ROOT/skills/start-issue/SKILL.md"
+}


### PR DESCRIPTION
## Summary

Skill-generated files (notes, scratchpads, questions, PR descriptions) were sometimes exposing in-progress deliberation — phrases like "oh wait, I now realize that..." written mid-generation before reasoning was complete. This adds `/pre-write`, a new foundation skill modeled on `/prose-style`, that defines one rule: complete all reasoning before writing the first word. Six content-generating skills now reference it at the point where they begin producing file content.

## Changes

- New `skills/pre-write/SKILL.md` foundation skill (`user-invocable: false`): defines the think-before-writing rule, names forbidden self-correction patterns ("oh wait," "I now realize," mid-stream course changes), and directs skills to use `/question` when context is incomplete rather than embedding uncertainty in output
- `skills/note/SKILL.md`: added `/pre-write` reference at the start of Step 3 (previously had no pre-write instruction at all)
- `skills/scratchpad/SKILL.md`, `skills/question/SKILL.md`, `skills/commit-msg/SKILL.md`: added `/pre-write` reference in the "Output format rule (read before writing anything)" section
- `skills/finish-issue/SKILL.md`: added `/pre-write` reference at the start of Step 5 before PR description generation
- `skills/start-issue/SKILL.md`: appended `/pre-write` reference and explicit "use `/question` before writing" gate to the Step 4 "before drafting" instruction
- New `tests/pre-write.bats`: 12 structural tests covering skill front matter, rule content, and cross-references in all 6 updated skills
- Documentation: CHANGELOG added; `README.md` and `skills/README.md` updated — `/pre-write` added to the "What Works Automatically" and "Auto-consulted skills" tables respectively

## Test Plan

- [x] All 162 existing tests pass
- [x] 12 new tests added for pre-write skill structure and cross-references in content-generating skills

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/pre-write` foundation skill ("think-before-writing") that requires all reasoning to be completed before generating any content, preventing in-progress deliberation from appearing in generated files.

* **Documentation**
  * Updated skill documentation to reference the pre-write requirement before content generation.

* **Tests**
  * Added validation tests for the pre-write skill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->