### PR TITLE
[issues/152] `/commit-msg` and `/finish-issue` must ignore intermediate steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.06.15.1
+
+### Added
+
+- `/commit-msg` and `/finish-issue` now anchor content generation to the final git diff instead of conversation context. When edits are added then reverted in the same working tree, or approaches are tried then replaced, the generated commit message and PR description no longer mention those intermediate states. The diff is the single source of truth for what changed. ([issues/152](https://github.com/couimet/my-claude-skills/issues/152))
+
 ## 2026.06.15
 
 ### Added

--- a/skills/commit-msg/SKILL.md
+++ b/skills/commit-msg/SKILL.md
@@ -3,7 +3,7 @@ name: commit-msg
 version: 2026.06.15@517a923
 description: Create a commit message file in .claude-work/commit-msgs/ with auto-numbered filenames. Focuses on WHY not WHAT. The diff already shows what changed. User reviews and commits manually.
 argument-hint: <description>
-allowed-tools: Read, Write, Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
+allowed-tools: Read, Write, Bash(git diff *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
 ---
 
 # Commit Message
@@ -21,6 +21,8 @@ See `/pre-write` for the think-before-writing rule: complete all reasoning befor
 ## Core Principle
 
 Focus on **WHY**, not **WHAT**. The git diff already shows what changed. The commit message explains the motivation, the problem being solved, and the benefits. Message depth should scale with the cognitive load of the change. Not every commit needs a body or Benefits section.
+
+The diff is also the filter for WHICH changes to describe. If a change was added then reverted in the same working tree, it never happened. Don't mention it. Only include reasoning and decisions that relate to files and changes visible in the actual diff.
 
 ## Step 1: Resolve the Target Path
 
@@ -45,6 +47,20 @@ Before writing, assess the change and pick a tier. The heuristic: if you can't a
 **Moderate**: subject + 1-2 sentence body. Use for: bug fixes, small refactors, config changes with non-obvious motivation. The body explains why.
 
 **Substantial**: subject + body + Benefits list. Use for: new features or capabilities, architectural changes, multi-file behavioral changes, performance improvements, security fixes.
+
+## Capture the Actual Change Set
+
+Run these two commands as parallel tool calls. They are independent.
+
+```bash
+git diff --stat
+```
+
+```bash
+git diff
+```
+
+Use the output as the single source of truth for what changed. Cross-reference your conversation context against it: drop any reasoning, decisions, or benefits that relate to files or edits not present in the diff.
 
 ## File Format
 
@@ -101,8 +117,10 @@ Formatting: see `/prose-style` for hard-wrap and GitHub-reference rules.
 
 ## Process
 
-1. Assess the change complexity (trivial, moderate, or substantial)
-2. Create the file using the matching tier format
-3. **Self-check for hard-wrapping.** Re-read the file you just wrote. For each paragraph in the body (text between blank lines, outside code blocks and the Benefits bullet list), verify it is a single continuous line. If you find a mid-sentence line break, rewrite that paragraph as one line. This check catches the most common failure. Always complete it. Also skim for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.
-4. Print the filepath in terminal
-5. Do NOT run `git commit`. The user reviews and commits manually.
+1. Capture the actual change set (see "Capture the Actual Change Set" above)
+2. Assess the change complexity (trivial, moderate, or substantial)
+3. Create the file using the matching tier format
+4. **Self-check for diff-relevance.** Cross-reference the message against the diff output. Remove any mention of files, changes, or reasoning not reflected in the diff.
+5. **Self-check for hard-wrapping.** Re-read the file you just wrote. For each paragraph in the body (text between blank lines, outside code blocks and the Benefits bullet list), verify it is a single continuous line. If you find a mid-sentence line break, rewrite that paragraph as one line. This check catches the most common failure. Always complete it. Also skim for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.
+6. Print the filepath in terminal
+7. Do NOT run `git commit`. The user reviews and commits manually.

--- a/skills/commit-msg/SKILL.md
+++ b/skills/commit-msg/SKILL.md
@@ -3,7 +3,7 @@ name: commit-msg
 version: 2026.06.15@517a923
 description: Create a commit message file in .claude-work/commit-msgs/ with auto-numbered filenames. Focuses on WHY not WHAT. The diff already shows what changed. User reviews and commits manually.
 argument-hint: <description>
-allowed-tools: Read, Write, Bash(git diff *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
+allowed-tools: Read, Write, AskUserQuestion, Bash(git diff *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
 ---
 
 # Commit Message
@@ -50,7 +50,7 @@ Before writing, assess the change and pick a tier. The heuristic: if you can't a
 
 ## Capture the Actual Change Set
 
-Run these two commands as parallel tool calls. They are independent.
+Run these four commands as parallel tool calls. They are independent.
 
 ```bash
 git diff --stat
@@ -60,7 +60,31 @@ git diff --stat
 git diff
 ```
 
-Use the output as the single source of truth for what changed. Cross-reference your conversation context against it: drop any reasoning, decisions, or benefits that relate to files or edits not present in the diff.
+```bash
+git diff --cached --stat
+```
+
+```bash
+git diff --cached
+```
+
+### Resolve the Effective Diff
+
+After capture, determine which diff(s) produced output:
+
+- **Only unstaged changes (plain `git diff` produced output, `--cached` is empty):** The user hasn't staged anything. Use the plain diff as the single source of truth.
+- **Only staged changes (`--cached` produced output, plain is empty):** The user staged everything. Use the cached diff.
+- **Both produced output (mix):** Use `AskUserQuestion` with a single question:
+
+  - **Header:** `Diff scope`
+  - **Question:** `Both staged and unstaged changes exist. Which set should the commit message describe?`
+  - **Options:**
+    1. `Staged only` — commit message describes only the staged changes (ready to commit)
+    2. `Both staged and unstaged` — commit message describes the full working-tree state
+
+  Set the effective diff(s) to the chosen scope before proceeding.
+
+Use the effective diff output as the single source of truth for what changed. Cross-reference your conversation context against it: drop any reasoning, decisions, or benefits that relate to files or edits not present in the effective diff.
 
 ## File Format
 

--- a/skills/finish-issue/SKILL.md
+++ b/skills/finish-issue/SKILL.md
@@ -114,6 +114,7 @@ Check if documentation updates are needed. Common touchpoints:
 Collect information from:
 
 - Commit history: read `Base branch:` from the resolved plan (recorded by `/start-issue` or `/start-side-quest`); fall back to `origin/main` if absent. Run: `git log --oneline <base-branch>..HEAD`
+- **Actual change set**: run `git diff --stat <base-branch>..HEAD` and `git diff <base-branch>..HEAD`. This is the single source of truth for what actually changed on the branch. Use it to filter which context is relevant — if a file or change doesn't appear in the diff, don't mention it in the PR description
 - **Resolved plan** (from Step 1b): read to extract the goal and rationale. This is the primary reference
 - Breadcrumbs (if exists): incorporate highlights into the PR description; use the paths below based on mode
 - Auxiliary working documents: PR-comment responses, interim analysis notes. Globbed separately so multi-round PR feedback isn't lost. Use the paths below based on mode
@@ -190,6 +191,8 @@ If side-quest mode:
 - Orthogonal improvement discovered during active development
 - Base branch: <branch this was cut from>
 ```
+
+**Diff-filtering rule:** The `## Changes` section must be derivable from the `git diff --stat` output captured in Step 4 — one bullet per logical grouping in the diff, not one bullet per conversation turn. Drop any mention of files, edits, or approaches that don't appear in the final diff. The `## Summary` must describe what shipped, not what was considered. The `## Key Discoveries` section should only include findings that relate to the final shipped changes. If an approach was tried then replaced, only the final approach matters.
 
 Formatting: see `/prose-style` for hard-wrap, code-reference, and GitHub-reference rules.
 


### PR DESCRIPTION
## Summary

When iterating on a branch with multiple edits, reverts, and approach changes, the conversation context accumulates every intermediate state. Both `/commit-msg` and `/finish-issue` previously generated content from that context, causing commit messages and PR descriptions to describe changes that never shipped. This fix anchors both skills to the final git diff as the single source of truth, so generated content describes what actually changed.

## Changes

- /commit-msg: added `git diff` to allowed-tools, new "Capture the Actual Change Set" step runs `git diff --stat` and `git diff` before writing, Core Principle amended to use the diff as a filter for which changes to describe, new diff-relevance self-check added to the Process section
- /finish-issue: Step 4 now captures the actual change set via `git diff --stat <base-branch>..HEAD` and `git diff <base-branch>..HEAD`, Step 5 added a diff-filtering rule — Changes must be derivable from `git diff --stat`, Summary describes what shipped not what was considered, Key Discoveries only covers findings relevant to final changes
- Documentation: CHANGELOG added (Fixed)

## Test Plan

- [x] All existing tests pass (162/162)
- [ ] Manual testing: run /commit-msg and /finish-issue on a branch with intermediate edits to verify only final changes are described

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * `/commit-msg` now anchors generated commit messages to actual git diff, excluding intermediate edits, reverts, and trial changes not present in the final repository state.
  * `/finish-issue` now anchors PR descriptions to actual shipped changes in the final diff, excluding abandoned or non-shipped approaches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->