### PR TITLE
[issues/155] Rename hook convention to singular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.06.17
+
+### Fixed
+
+- Renamed hook skill convention from plural `{parent}-hooks` to singular `{parent}-hook` (`start-issue-hook`, `finish-issue-hook`, `start-side-quest-hook`). A project defines exactly one hook skill per parent skill, so singular is more accurate. ([issues/155](https://github.com/couimet/my-claude-skills/issues/155))
+
 ## 2026.06.16.1
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ To customize:
 
 Some skills (`/start-issue`, `/finish-issue`, `/start-side-quest`) support project-local hook skills — foundation skills that a project can define in its own `.claude/skills/` directory to add requirements without forking the global skill. For example, a project that maintains QA test cases can add a hook that injects a TC cross-reference step into every issue plan.
 
-The naming convention is `{parent-skill}-hooks` (e.g., `start-issue-hooks`). Hook skills are add-requirements-only — they contribute constraints and content, but the parent skill owns all behavioral decisions. See [ADR 001](docs/ADR/001-skill-extension-hooks.md) for the full design rationale, tradeoffs, and rejected alternatives.
+The naming convention is `{parent-skill}-hook` (e.g., `start-issue-hook`). Hook skills are add-requirements-only — they contribute constraints and content, but the parent skill owns all behavioral decisions. See [ADR 001](docs/ADR/001-skill-extension-hooks.md) for the full design rationale, tradeoffs, and rejected alternatives.
 
 If you build something useful, PRs are welcome. These skills evolved from my own workflow friction — yours will be different, and that's the point.
 

--- a/docs/ADR/001-skill-extension-hooks.md
+++ b/docs/ADR/001-skill-extension-hooks.md
@@ -14,7 +14,7 @@ The question: how can a project add these extensions without forking the global 
 
 ## Decision
 
-**Add prose references to hook skills at specific insertion points in the global skills.** When a global skill references `/start-issue-hooks` in its instructions, Claude Code's native skill resolution searches all directories (enterprise, personal, project, plugin) for a skill with that name. If found, it is loaded as additional context and its requirements are incorporated. If not found, the reference is inert and the vanilla skill runs unchanged.
+**Add prose references to hook skills at specific insertion points in the global skills.** When a global skill references `/start-issue-hook` in its instructions, Claude Code's native skill resolution searches all directories (enterprise, personal, project, plugin) for a skill with that name. If found, it is loaded as additional context and its requirements are incorporated. If not found, the reference is inert and the vanilla skill runs unchanged.
 
 This is purely a convention: a few lines of prose added to existing SKILL.md files. No new infrastructure, no configuration files, no settings changes. The mechanism is already built into Claude Code.
 
@@ -22,9 +22,9 @@ This is purely a convention: a few lines of prose added to existing SKILL.md fil
 
 | Skill | Hook skill name | Insertion points |
 | --- | --- | --- |
-| `start-issue` | `start-issue-hooks` | After context gathering, before plan generation |
-| `finish-issue` | `finish-issue-hooks` | During verification |
-| `start-side-quest` | `start-side-quest-hooks` | After branch creation, before plan generation |
+| `start-issue` | `start-issue-hook` | After context gathering, before plan generation |
+| `finish-issue` | `finish-issue-hook` | During verification |
+| `start-side-quest` | `start-side-quest-hook` | After branch creation, before plan generation |
 
 ### Skills explicitly excluded
 
@@ -32,7 +32,7 @@ This is purely a convention: a few lines of prose added to existing SKILL.md fil
 
 ### Hook skill conventions
 
-- **Naming:** `{parent-skill}-hooks`, e.g. `start-issue-hooks`, `finish-issue-hooks`
+- **Naming:** `{parent-skill}-hook`, e.g. `start-issue-hook`, `finish-issue-hook`
 - **Type:** Foundation skills (`user-invocable: false`), following the existing `pre-write` and `issue-context` pattern. Hooks are consulted by parent skills, never invoked directly.
 - **One hook per parent:** A single hook skill defines all project-specific requirements. No need to split into multiple hook skills per concern.
 - **Add-requirements only:** Hooks specify additional constraints, content, or checks. The parent skill owns all behavioral decisions. This keeps the hook contract simple and avoids branching logic in the parent skill that would burn tokens on existence checks.
@@ -41,7 +41,7 @@ This is purely a convention: a few lines of prose added to existing SKILL.md fil
 
 ### Positive
 
-- **Zero overhead for non-extending projects.** If `.claude/skills/start-issue-hooks/SKILL.md` doesn't exist, the reference resolves to nothing and the vanilla skill runs identically to before.
+- **Zero overhead for non-extending projects.** If `.claude/skills/start-issue-hook/SKILL.md` doesn't exist, the reference resolves to nothing and the vanilla skill runs identically to before.
 - **Discoverable.** A developer can look at `.claude/skills/` and immediately understand which workflows are extended. The naming convention is predictable.
 - **Composable.** Different projects define different hooks. Enterprise orgs can define org-wide hooks. No conflicts.
 - **Portable.** Hook skills are committed to the project repo. A new developer cloning the repo gets the hooks automatically. A developer on a machine without the project's `.claude/skills/` directory gets vanilla behavior with no errors.
@@ -51,7 +51,7 @@ This is purely a convention: a few lines of prose added to existing SKILL.md fil
 
 - **Cannot replace behavior.** Hooks can only add requirements, not change how the parent skill makes decisions. A project that wants to change note's target directory resolution cannot do so via a hook. This is intentional — behavior replacement would require the parent skill to add branching logic at every decision point, burning tokens on existence checks for a feature most projects won't use.
 - **Soft check, not a hard gate.** The hook fires when Claude reads the parent skill and resolves the reference. There is no programmatic guarantee that the hook was consulted. This is inherent to the LLM-based architecture — skills are instructions, not code.
-- **Naming collision risk.** If a project creates a skill with the same name as a global skill, the global skill wins (personal > project in Claude Code's priority model). The `-hooks` suffix avoids this by using names that don't exist in the global set.
+- **Naming collision risk.** If a project creates a skill with the same name as a global skill, the global skill wins (personal > project in Claude Code's priority model). The `-hook` suffix avoids this by using names that don't exist in the global set.
 
 ## Alternatives Considered
 

--- a/skills/finish-issue/SKILL.md
+++ b/skills/finish-issue/SKILL.md
@@ -80,7 +80,7 @@ git status
 - If formatting makes changes → prepare a commit
 - If tests fail → investigate and fix before proceeding
 - If uncommitted changes exist → notify user
-- **Check for project-local hooks**: if the project has a `/finish-issue-hooks` skill (foundation skill at `.claude/skills/finish-issue-hooks/SKILL.md`), it is loaded as additional context automatically. Read it and incorporate whatever it specifies. If no such skill exists, continue with the vanilla workflow. See `/skill-hooks` for the full extension mechanism.
+- **Check for project-local hooks**: if the project has a `/finish-issue-hook` skill (foundation skill at `.claude/skills/finish-issue-hook/SKILL.md`), it is loaded as additional context automatically. Read it and incorporate whatever it specifies. If no such skill exists, continue with the vanilla workflow. See `/skill-hooks` for the full extension mechanism.
 
 ## Step 3: Documentation Review
 

--- a/skills/skill-hooks/SKILL.md
+++ b/skills/skill-hooks/SKILL.md
@@ -20,9 +20,9 @@ A project creates a foundation skill in `.claude/skills/` with the name `{parent
 
 | Parent skill | Hook skill name | What it can add |
 | --- | --- | --- |
-| `/start-issue` | `start-issue-hooks` | Additional plan steps, context-gathering, validation gates |
-| `/finish-issue` | `finish-issue-hooks` | Additional verification steps, PR description sections |
-| `/start-side-quest` | `start-side-quest-hooks` | Additional plan steps, context-gathering, validation gates |
+| `/start-issue` | `start-issue-hook` | Additional plan steps, context-gathering, validation gates |
+| `/finish-issue` | `finish-issue-hook` | Additional verification steps, PR description sections |
+| `/start-side-quest` | `start-side-quest-hook` | Additional plan steps, context-gathering, validation gates |
 
 Hook skills are foundation skills (`user-invocable: false`). They are consulted by their parent skill, never invoked directly by the user.
 
@@ -34,11 +34,11 @@ Projects wanting to replace specific behaviors (e.g., changing where `/note` wri
 
 ## Example
 
-RangeLink wants every issue plan to cross-reference QA test cases. It creates `.claude/skills/start-issue-hooks/SKILL.md`:
+RangeLink wants every issue plan to cross-reference QA test cases. It creates `.claude/skills/start-issue-hook/SKILL.md`:
 
 ```yaml
 ---
-name: start-issue-hooks
+name: start-issue-hook
 description: QA test case cross-referencing for /start-issue plans
 user-invocable: false
 allowed-tools: Read, Grep, Glob

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -74,7 +74,7 @@ Where `<NUMBER>` is the GitHub issue number (e.g., `issues/223`) and `<BASE_BRAN
   - Existing patterns to follow
   - Test files that will need updates
 - **Check integration points**: review the project's entry points, configuration, documentation, and discoverability conventions for anything the change might affect
-- **Check for project-local hooks**: if the project has a `/start-issue-hooks` skill (foundation skill at `.claude/skills/start-issue-hooks/SKILL.md`), it is loaded as additional context automatically. Read it and incorporate whatever it specifies into the plan generated in Step 4. If no such skill exists, continue with the vanilla plan. See `/skill-hooks` for the full extension mechanism.
+- **Check for project-local hooks**: if the project has a `/start-issue-hook` skill (foundation skill at `.claude/skills/start-issue-hook/SKILL.md`), it is loaded as additional context automatically. Read it and incorporate whatever it specifies into the plan generated in Step 4. If no such skill exists, continue with the vanilla plan. See `/skill-hooks` for the full extension mechanism.
 
 ## Step 4: Create Implementation Plan Working Document
 

--- a/skills/start-side-quest/SKILL.md
+++ b/skills/start-side-quest/SKILL.md
@@ -55,7 +55,7 @@ Examples:
 - `side-quest/fix-result-type-usage`
 - `side-quest/cleanup-test-mocks`
 
-**Check for project-local hooks**: if the project has a `/start-side-quest-hooks` skill (foundation skill at `.claude/skills/start-side-quest-hooks/SKILL.md`), it is loaded as additional context automatically. Read it and incorporate whatever it specifies into the plan generated in Step 3. If no such skill exists, continue with the vanilla plan. See `/skill-hooks` for the full extension mechanism.
+**Check for project-local hooks**: if the project has a `/start-side-quest-hook` skill (foundation skill at `.claude/skills/start-side-quest-hook/SKILL.md`), it is loaded as additional context automatically. Read it and incorporate whatever it specifies into the plan generated in Step 3. If no such skill exists, continue with the vanilla plan. See `/skill-hooks` for the full extension mechanism.
 
 ## Step 3: Create Implementation Working Document
 

--- a/tests/skill-hooks.bats
+++ b/tests/skill-hooks.bats
@@ -26,15 +26,15 @@ load test_helper
 # start-issue hook reference
 # =============================================================
 
-@test "start-issue skill: references /start-issue-hooks" {
-  grep -q "/start-issue-hooks" "$PROJECT_ROOT/skills/start-issue/SKILL.md"
+@test "start-issue skill: references /start-issue-hook" {
+  grep -q "/start-issue-hook" "$PROJECT_ROOT/skills/start-issue/SKILL.md"
 }
 
 @test "start-issue skill: hook reference appears after context gathering (Step 3)" {
   # The hook reference should appear after the Step 3 header and before Step 4
   STEP3_LINE=$(grep -n "^## Step 3: Gather Full Context" "$PROJECT_ROOT/skills/start-issue/SKILL.md" | cut -d: -f1)
   STEP4_LINE=$(grep -n "^## Step 4: Create Implementation Plan" "$PROJECT_ROOT/skills/start-issue/SKILL.md" | cut -d: -f1)
-  HOOK_LINE=$(grep -n "/start-issue-hooks" "$PROJECT_ROOT/skills/start-issue/SKILL.md" | cut -d: -f1)
+  HOOK_LINE=$(grep -n "/start-issue-hook" "$PROJECT_ROOT/skills/start-issue/SKILL.md" | cut -d: -f1)
 
   [ "$HOOK_LINE" -gt "$STEP3_LINE" ]
   [ "$HOOK_LINE" -lt "$STEP4_LINE" ]
@@ -44,21 +44,21 @@ load test_helper
 # finish-issue hook references
 # =============================================================
 
-@test "finish-issue skill: references /finish-issue-hooks" {
-  grep -q "/finish-issue-hooks" "$PROJECT_ROOT/skills/finish-issue/SKILL.md"
+@test "finish-issue skill: references /finish-issue-hook" {
+  grep -q "/finish-issue-hook" "$PROJECT_ROOT/skills/finish-issue/SKILL.md"
 }
 
 @test "finish-issue skill: hook reference appears in verification (Step 2)" {
   STEP2_LINE=$(grep -n "^## Step 2: Pre-PR Verification" "$PROJECT_ROOT/skills/finish-issue/SKILL.md" | cut -d: -f1)
   STEP3_LINE=$(grep -n "^## Step 3: Documentation Review" "$PROJECT_ROOT/skills/finish-issue/SKILL.md" | cut -d: -f1)
-  HOOK_LINE=$(grep -n "/finish-issue-hooks" "$PROJECT_ROOT/skills/finish-issue/SKILL.md" | cut -d: -f1)
+  HOOK_LINE=$(grep -n "/finish-issue-hook" "$PROJECT_ROOT/skills/finish-issue/SKILL.md" | cut -d: -f1)
 
   [ "$HOOK_LINE" -gt "$STEP2_LINE" ]
   [ "$HOOK_LINE" -lt "$STEP3_LINE" ]
 }
 
-@test "finish-issue skill: has exactly one /finish-issue-hooks reference" {
-  COUNT=$(grep -c "/finish-issue-hooks" "$PROJECT_ROOT/skills/finish-issue/SKILL.md")
+@test "finish-issue skill: has exactly one /finish-issue-hook reference" {
+  COUNT=$(grep -c "/finish-issue-hook" "$PROJECT_ROOT/skills/finish-issue/SKILL.md")
   [ "$COUNT" -eq 1 ]
 }
 
@@ -66,14 +66,14 @@ load test_helper
 # start-side-quest hook reference
 # =============================================================
 
-@test "start-side-quest skill: references /start-side-quest-hooks" {
-  grep -q "/start-side-quest-hooks" "$PROJECT_ROOT/skills/start-side-quest/SKILL.md"
+@test "start-side-quest skill: references /start-side-quest-hook" {
+  grep -q "/start-side-quest-hook" "$PROJECT_ROOT/skills/start-side-quest/SKILL.md"
 }
 
 @test "start-side-quest skill: hook reference appears after branch creation (Step 2) and before plan generation (Step 3)" {
   STEP2_LINE=$(grep -n "^## Step 2: Create Side-Quest Branch" "$PROJECT_ROOT/skills/start-side-quest/SKILL.md" | cut -d: -f1)
   STEP3_LINE=$(grep -n "^## Step 3: Create Implementation Working Document" "$PROJECT_ROOT/skills/start-side-quest/SKILL.md" | cut -d: -f1)
-  HOOK_LINE=$(grep -n "/start-side-quest-hooks" "$PROJECT_ROOT/skills/start-side-quest/SKILL.md" | cut -d: -f1)
+  HOOK_LINE=$(grep -n "/start-side-quest-hook" "$PROJECT_ROOT/skills/start-side-quest/SKILL.md" | cut -d: -f1)
 
   [ "$HOOK_LINE" -gt "$STEP2_LINE" ]
   [ "$HOOK_LINE" -lt "$STEP3_LINE" ]


### PR DESCRIPTION
## Summary

The hook skill naming convention used a misleading plural suffix (`{parent}-hooks`). A project defines exactly one hook skill per parent skill, so singular (`{parent}-hook`) is more accurate. This renames `start-issue-hooks` → `start-issue-hook`, `finish-issue-hooks` → `finish-issue-hook`, and `start-side-quest-hooks` → `start-side-quest-hook` across all documentation, skill files, the ADR, and tests.

## Changes

- Convention table and example in the `skill-hooks` foundation skill updated to singular naming
- Hook references in `start-issue`, `finish-issue`, and `start-side-quest` updated to reference the singular hook skill names
- ADR 001 naming convention, example path, and collision-risk rationale updated
- README convention description updated to `{parent}-hook`
- Test suite (6 assertions in `tests/skill-hooks.bats`) updated to match the new names
- CHANGELOG entry added under Fixed

## Test Plan

- [x] All existing tests pass (186/186)
- [ ] Manual testing: verify `/start-issue`, `/finish-issue`, and `/start-side-quest` still resolve hook references correctly

## Related

- Post-merge fix for https://github.com/couimet/my-claude-skills/pull/157
- Part of https://github.com/couimet/my-claude-skills/issues/155

@coderabbitai ignore