### PR TITLE
[issues/166] Add missing `target-path.sh` to `allowed-tools` across skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.06.18.1
+
+### Fixed
+
+- Added `target-path.sh` to `allowed-tools` for all five user-invocable skills (`start-issue`, `finish-issue`, `start-side-quest`, `tackle-pr-comment`, `create-github-issue`) that cross-reference foundation skills which call it. Previously, following a foundation skill's instructions inline (without going through `Skill()`) would run the script against the top-level skill's `allowed-tools` and prompt the user. ([issues/166](https://github.com/couimet/my-claude-skills/issues/166))
+
 ## 2026.06.18
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ allowed-tools: Read, Write, Glob, Grep, Bash(git status *), Bash(gh issue view *
 
 **`allowed-tools:`** — restricts which Bash commands the skill may use. Use specific patterns (`Bash(git checkout *)`) rather than `Bash(*)` unless the skill genuinely needs unrestricted shell access (only `tackle-scratchpad-block` does, because it runs arbitrary user-authored steps).
 
+**Transitive coverage rule:** When a skill cross-references a foundation skill that calls a script (e.g., `/question` calls `target-path.sh` from `issue-context`), the cross-referencing skill must also declare that script in its own `allowed-tools`. The AI does not always route through `Skill()` when following a cross-reference — it may follow the foundation skill's instructions inline, and those Bash calls are checked against the top-level skill's `allowed-tools`. Missing entries cause permission prompts.
+
 **`version:`** is managed by `make stamp` — never edit it by hand.
 
 ### Skill Cross-References

--- a/skills/create-github-issue/SKILL.md
+++ b/skills/create-github-issue/SKILL.md
@@ -3,7 +3,7 @@ name: create-github-issue
 version: 2026.06.18@b488abf
 description: Create a GitHub issue from a file draft or inline description, with smart label discovery and sub-issue linking
 argument-hint: <file-path-or-title>
-allowed-tools: Read, Write, Glob, Bash(gh repo view *), Bash(gh label list *), Bash(gh issue create *), Bash(*/skills/create-github-issue/link-sub-issue.sh *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
+allowed-tools: Read, Write, Glob, Bash(gh repo view *), Bash(gh label list *), Bash(gh issue create *), Bash(*/skills/create-github-issue/link-sub-issue.sh *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *)
 ---
 
 # Create GitHub Issue

--- a/skills/finish-issue/SKILL.md
+++ b/skills/finish-issue/SKILL.md
@@ -3,7 +3,7 @@ name: finish-issue
 version: 2026.06.18@b488abf
 description: Wrap up issue or side-quest work on the current issues/* or side-quest/* branch. Runs verification, checks documentation needs, and generates a PR description
 argument-hint: [optional: issue-number-or-url]
-allowed-tools: Read, Write, Glob, Grep, AskUserQuestion, Bash(git branch --show-current), Bash(git status), Bash(git log *), Bash(git diff *), Bash(make lint-fix *), Bash(make test *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
+allowed-tools: Read, Write, Glob, Grep, AskUserQuestion, Bash(git branch --show-current), Bash(git status), Bash(git log *), Bash(git diff *), Bash(make lint-fix *), Bash(make test *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *)
 ---
 
 # Finish Issue

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -3,7 +3,7 @@ name: start-issue
 version: 2026.06.18@b488abf
 description: Start working on a GitHub issue - analyze, explore codebase, and create detailed implementation plan
 argument-hint: <github-issue-url> [--scratchpad]
-allowed-tools: Read, Write, Glob, Grep, Bash(git branch --show-current), Bash(git fetch *), Bash(git checkout *), Bash(gh issue view *), Bash(gh issue edit * --add-assignee *), Bash(gh api graphql *), Bash(gh issue comment *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/start-issue/update-project-status.sh *)
+allowed-tools: Read, Write, Glob, Grep, Bash(git branch --show-current), Bash(git fetch *), Bash(git checkout *), Bash(gh issue view *), Bash(gh issue edit * --add-assignee *), Bash(gh api graphql *), Bash(gh issue comment *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/start-issue/update-project-status.sh *)
 ---
 
 # Start Issue

--- a/skills/start-side-quest/SKILL.md
+++ b/skills/start-side-quest/SKILL.md
@@ -3,7 +3,7 @@ name: start-side-quest
 version: 2026.06.18@b488abf
 description: Start a side-quest branch for orthogonal improvements discovered while working on an issue
 argument-hint: <description | path/to/file.ts#L10-L20> [--scratchpad]
-allowed-tools: Read, Write, Glob, Grep, Bash(git fetch *), Bash(git checkout *), Bash(git branch --show-current), Bash(git status *), Bash(git stash *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
+allowed-tools: Read, Write, Glob, Grep, Bash(git fetch *), Bash(git checkout *), Bash(git branch --show-current), Bash(git status *), Bash(git stash *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *)
 ---
 
 # Start Side-Quest

--- a/skills/tackle-pr-comment/SKILL.md
+++ b/skills/tackle-pr-comment/SKILL.md
@@ -3,7 +3,7 @@ name: tackle-pr-comment
 version: 2026.06.18@b488abf
 description: Tackle a PR comment - analyze feedback, explore code, and create implementation working document
 argument-hint: <pr-comment-url> [--scratchpad]
-allowed-tools: Read, Glob, Grep, Write, Bash(gh api repos/*/*/pulls/*/reviews/*), Bash(gh api repos/*/*/pulls/comments/*), Bash(gh api repos/*/*/issues/comments/*), Bash(gh api repos/*/*/pulls/*/comments*), Bash(gh api repos/*/*/issues/*/comments*), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
+allowed-tools: Read, Glob, Grep, Write, Bash(gh api repos/*/*/pulls/*/reviews/*), Bash(gh api repos/*/*/pulls/comments/*), Bash(gh api repos/*/*/issues/comments/*), Bash(gh api repos/*/*/pulls/*/comments*), Bash(gh api repos/*/*/issues/*/comments*), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *)
 ---
 
 # Tackle PR Comment


### PR DESCRIPTION
## Summary

Five user-invocable skills cross-reference foundation skills (`/question`, `/scratchpad`, `/commit-msg`) that call `target-path.sh`, but none declared that script in their own `allowed-tools`. This caused permission prompts when the AI followed foundation skill instructions inline instead of routing through `Skill()`. The fix adds the missing entry to all five and documents the transitive coverage rule in CLAUDE.md.

## Changes

- Five user-invocable skills (`start-issue`, `finish-issue`, `start-side-quest`, `tackle-pr-comment`, `create-github-issue`) now declare `Bash(*/skills/issue-context/target-path.sh *)` in their `allowed-tools`, closing a transitive coverage gap that caused permission prompts when cross-referencing foundation skills that call the script
- CLAUDE.md now documents the transitive coverage rule for `allowed-tools`: when a skill cross-references a foundation skill that calls a script, the cross-referencing skill must also declare that script, because the AI may follow the foundation skill's instructions inline rather than going through `Skill()`
- CHANGELOG: fixed entry for 2026.06.18.1

## Key Discoveries

A full audit confirmed that every skill that directly invokes a script already declares it in `allowed-tools`. The gap was purely transitive: user-invocable skills cross-reference foundation skills via prose (e.g., "Use `/question` to create a questions file"), and when the AI follows those instructions inline, the Bash calls are checked against the top-level skill's `allowed-tools`, not the foundation skill's. The `ensure-gitignore.sh` script was already covered everywhere; only `target-path.sh` was missing from the five affected skills.

## Test Plan

- [x] All 186 existing tests pass
- [x] `make lint` reports 0 errors across all 34 Markdown files
- [ ] Manual testing: invoke any of the five affected skills on a fresh project and confirm no permission prompt for `target-path.sh`

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/166

@coderabbitai ignore