### PR TITLE
[issues/172] Fix `update-project-status.sh` path for non-vendored repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.06.25
+
+### Fixed
+
+- Fixed `update-project-status.sh` path in `/start-issue` to use `~/.claude/skills/` instead of `<project-root>/skills/`, so the script is found regardless of whether the target project has vendored skills. ([issues/172](https://github.com/couimet/my-claude-skills/issues/172))
+
 ## 2026.06.18.1
 
 ### Fixed

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -39,7 +39,7 @@ The assign is additive: existing assignees are preserved, not replaced. The comm
 After assignment, detect whether the issue belongs to any GitHub Projects V2 boards and move those project items to "In Progress" status:
 
 ```bash
-<project-root>/skills/start-issue/update-project-status.sh <owner> <repo> <issue_number>
+~/.claude/skills/start-issue/update-project-status.sh <owner> <repo> <issue_number>
 ```
 
 Where `<owner>` and `<repo>` are extracted from the issue URL, and `<issue_number>` is the GitHub issue number.


### PR DESCRIPTION
## Summary

`/start-issue` Step 1b referenced `update-project-status.sh` with a `<project-root>/skills/` prefix that only resolves when the target project has vendored the skill. In all other repos the script wasn't found, so the project board update silently skipped. Changed the path to `~/.claude/skills/start-issue/` — the skill's own install directory, where the script always lives alongside `SKILL.md`.

## Changes

- `/start-issue` Step 1b now references `update-project-status.sh` via `~/.claude/skills/start-issue/` instead of `<project-root>/skills/start-issue/`, fixing a path resolution failure in repos without vendored skills (via `skills/start-issue/SKILL.md`)
- CHANGELOG entry added under `## 2026.06.25`

## Key Discoveries

The `allowed-tools` line already used `Bash(*/skills/start-issue/update-project-status.sh *)` with a `*` wildcard that matches any parent directory — the permission system was never the problem. The bug was purely in the instruction text, where `<project-root>` directed the AI to a path that only exists in vendored setups. Other skills (e.g., `/scratchpad`) don't use `<project-root>` for script paths at all.

## Test Plan

- [ ] All existing tests pass (186/186)
- [ ] No new tests needed — the `update-project-status.bats` tests cover the script's behavior, and the path change doesn't affect functionality

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/172

@coderabbitai ignore