### PR TITLE
[issues/173] Make `.claude-work` path resolution `git worktree`-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   ci:
@@ -26,3 +27,4 @@ jobs:
       - uses: couimet/github-actions/bats-test@main
         with:
           test-directory: tests
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.06.25.1
+
+### Changed
+
+- Made `.claude-work/` path resolution git worktree-aware. In a linked git worktree, `.claude-work/` now lives at the main checkout root (shared across all worktrees) instead of the worktree root, preventing duplicate artifacts. Added `claude-work-root.sh` helper that returns the absolute shared path. Updated `target-path.sh`, `note`, `breadcrumb`, and all reading skills (`finish-issue`, `cleanup-issue`, `start-issue`, `start-side-quest`, `tackle-scratchpad-block`, `tackle-pr-comment`, `create-github-issue`) to use it. All `.claude-work/` paths are now absolute to avoid ambiguity. ([issues/173](https://github.com/couimet/my-claude-skills/issues/173))
+
 ## 2026.06.25
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ All ephemeral working files live under `.claude-work/` (git-ignored). Never comm
   commit-msgs/
 ```
 
+**Git worktree sharing:** `.claude-work/` lives at the main checkout root (resolved by `skills/issue-context/claude-work-root.sh`). In the primary checkout this is `git rev-parse --show-toplevel` (unchanged from before). In a linked git worktree it is `dirname(git rev-parse --git-common-dir)` — the main checkout — so all worktrees of the same repo share a single `.claude-work/` copy. Skills that write `.claude-work/` files use absolute paths to avoid ambiguity about which worktree the files live in. Skills never edit source files outside the current worktree; the shared location is only for ephemeral working artifacts.
+
 **Auto-numbering:** File sequence numbers (`NNNN`) are managed by `skills/auto-number/auto-number.sh`. Foundation skills call it automatically — don't reimplement the logic.
 
 ## CHANGELOG Conventions

--- a/skills/breadcrumb/SKILL.md
+++ b/skills/breadcrumb/SKILL.md
@@ -3,7 +3,7 @@ name: breadcrumb
 version: 2026.06.25@7353cfe
 description: Drop a timestamped note for the current issue - collected by /finish-issue for PR descriptions
 argument-hint: <note text>
-allowed-tools: Read, Write, Bash(git branch --show-current), Bash(date *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *)
+allowed-tools: Read, Write, Bash(git branch --show-current), Bash(date *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Breadcrumb
@@ -14,10 +14,14 @@ Drop a timestamped note along your journey through an issue. When you run `/fini
 
 ## Step 1: Detect Branch Context
 
-Read the current branch:
+Run both commands as parallel tool calls. They are independent:
 
 ```bash
 git branch --show-current
+```
+
+```bash
+~/.claude/skills/issue-context/claude-work-root.sh
 ```
 
 Extract the breadcrumb identifier based on branch pattern:
@@ -32,6 +36,8 @@ Extract the breadcrumb identifier based on branch pattern:
 - Print: "Not on a work branch. Breadcrumbs require an `issues/*` or `side-quest/*` branch."
 - STOP
 
+Use the stdout of `claude-work-root.sh` as the base path (e.g., `/Users/x/project/.claude-work`). This script automatically detects git worktrees and returns the shared `.claude-work/` location.
+
 ## Step 2: Validate Input
 
 **If $ARGUMENTS is empty or whitespace:**
@@ -43,10 +49,10 @@ Extract the breadcrumb identifier based on branch pattern:
 
 **File location depends on branch pattern:**
 
-- Issues: `.claude-work/issues/<ID>/breadcrumb.md`
-- Side-quests: `.claude-work/breadcrumb-<slug>.md`
+- Issues: `<base>/issues/<ID>/breadcrumb.md`
+- Side-quests: `<base>/breadcrumb-<slug>.md`
 
-Where `<ID>` or `<slug>` is the value extracted in Step 1.
+Where `<base>` is the stdout from `claude-work-root.sh`, `<ID>` or `<slug>` is the value extracted in Step 1.
 
 **If file doesn't exist**, create it with `<!-- markdownlint-disable MD013 -->` as the very first line, then the header:
 
@@ -69,10 +75,10 @@ date "+%Y-%m-%d %H:%M:%S"
 
 ## Step 4: Confirm
 
-Print a brief confirmation with the file path:
+Print a brief confirmation with the file path (the full absolute path from `<base>`):
 
-- Issues: `Breadcrumb dropped in .claude-work/issues/<ID>/breadcrumb.md`
-- Side-quests: `Breadcrumb dropped in .claude-work/breadcrumb-<slug>.md`
+- Issues: `Breadcrumb dropped in <base>/issues/<ID>/breadcrumb.md`
+- Side-quests: `Breadcrumb dropped in <base>/breadcrumb-<slug>.md`
 
 Confirm by printing the path as shown above. Length: one line. Do NOT print the full file contents.
 

--- a/skills/cleanup-issue/SKILL.md
+++ b/skills/cleanup-issue/SKILL.md
@@ -3,7 +3,7 @@ name: cleanup-issue
 version: 2026.06.25@7353cfe
 description: Delete an issue's working directory (.claude-work/issues/<ID>/) after confirming with the user via interactive prompt
 argument-hint: [optional: issue-number]
-allowed-tools: Read, Glob, AskUserQuestion, Bash(git branch --show-current), Bash(rm -rf .claude-work/issues/*)
+allowed-tools: Read, Glob, AskUserQuestion, Bash(git branch --show-current), Bash(rm -rf *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Cleanup Issue
@@ -32,25 +32,33 @@ Before proceeding, the extracted ID MUST match `^[A-Za-z0-9._-]+$`. If it contai
 
 - Print: "Refusing to proceed: extracted issue ID `<ID>` contains unsafe characters. Expected `[A-Za-z0-9._-]+`."
 
-This is a hard guard: the ID is interpolated into `rm -rf .claude-work/issues/<ID>` in Step 4, and an unsanitized value (e.g. `..` or one with embedded path separators) could delete the wrong directory. Fail closed on any surprise.
+This is a hard guard: the ID is interpolated into `rm -rf <base>/issues/<ID>` in Step 4, and an unsanitized value (e.g. `..` or one with embedded path separators) could delete the wrong directory. Fail closed on any surprise.
 
 ## Step 2: Check for Issue Directory
+
+First, resolve the `.claude-work/` root directory:
+
+```bash
+~/.claude/skills/issue-context/claude-work-root.sh
+```
+
+Use the stdout as `<base>` for all `.claude-work/` paths below. This script automatically detects git worktrees and returns the shared location.
 
 Check if the issue directory exists:
 
 ```text
-.claude-work/issues/<ID>/
+<base>/issues/<ID>/
 ```
 
 Use Glob to list contents:
 
 ```text
-Glob(pattern="**/*", path=".claude-work/issues/<ID>")
+Glob(pattern="**/*", path="<base>/issues/<ID>")
 ```
 
 **If directory doesn't exist or is empty:**
 
-- Print: "No working directory found for issue #`<ID>` at `.claude-work/issues/<ID>/`."
+- Print: "No working directory found for issue #`<ID>` at `<base>/issues/<ID>/`."
 - Skip to Step 5
 
 ## Step 3: Confirm Deletion
@@ -59,9 +67,9 @@ Use `AskUserQuestion` to prompt for confirmation. Include the full directory pat
 
 ```text
 AskUserQuestion(
-  question: "Delete working directory for issue #<ID>?\n\n.claude-work/issues/<ID>/ contains:\n<file list from Step 2>\n\nThis is irreversible.",
+  question: "Delete working directory for issue #<ID>?\n\n<base>/issues/<ID>/ contains:\n<file list from Step 2>\n\nThis is irreversible.",
   options: [
-    { label: "Delete", description: "Remove .claude-work/issues/<ID>/ and all contents" },
+    { label: "Delete", description: "Remove <base>/issues/<ID>/ and all contents" },
     { label: "Keep", description: "Leave everything untouched" }
   ]
 )
@@ -70,30 +78,30 @@ AskUserQuestion(
 ## Step 4: Act on Answer
 
 - **Delete** → proceed to deletion
-- **Keep** → print "Keeping `.claude-work/issues/<ID>/` untouched." and STOP
+- **Keep** → print "Keeping `<base>/issues/<ID>/` untouched." and STOP
 
 ### Delete
 
 Only reached if the ID passed the whitelist check in Step 1. Do not run this step otherwise.
 
 ```bash
-rm -rf .claude-work/issues/<ID>
+rm -rf <base>/issues/<ID>
 ```
 
 Print:
 
 ```text
-Cleaned up .claude-work/issues/<ID>/. All working files removed.
+Cleaned up <base>/issues/<ID>/. All working files removed.
 ```
 
 ## Step 5: Check for Side-Quest Artifacts
 
-Regardless of whether the issue directory existed or was deleted, scan for orphaned side-quest files in the `.claude-work/` root:
+Regardless of whether the issue directory existed or was deleted, scan for orphaned side-quest files in the `.claude-work/` root (using `<base>` from Step 2):
 
 ```text
-Glob(pattern="breadcrumb-*.md", path=".claude-work")
-Glob(pattern="scratchpads/*side-quest*", path=".claude-work")
-Glob(pattern="commit-msgs/*side-quest*", path=".claude-work")
+Glob(pattern="breadcrumb-*.md", path="<base>")
+Glob(pattern="scratchpads/*side-quest*", path="<base>")
+Glob(pattern="commit-msgs/*side-quest*", path="<base>")
 ```
 
 **If side-quest artifacts are found:**

--- a/skills/cleanup-issue/SKILL.md
+++ b/skills/cleanup-issue/SKILL.md
@@ -3,7 +3,7 @@ name: cleanup-issue
 version: 2026.06.25@7353cfe
 description: Delete an issue's working directory (.claude-work/issues/<ID>/) after confirming with the user via interactive prompt
 argument-hint: [optional: issue-number]
-allowed-tools: Read, Glob, AskUserQuestion, Bash(git branch --show-current), Bash(rm -rf *), Bash(*/skills/issue-context/claude-work-root.sh *)
+allowed-tools: Read, Glob, AskUserQuestion, Bash(git branch --show-current), Bash(*/skills/cleanup-issue/remove-issue-dir.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Cleanup Issue
@@ -28,11 +28,7 @@ Extract the issue ID from the `issues/<ID>` pattern (numeric prefix before the f
 
 ### Validate the ID
 
-Before proceeding, the extracted ID MUST match `^[A-Za-z0-9._-]+$`. If it contains slashes, whitespace, shell metacharacters, or path-traversal sequences (`..`, `/`, spaces, `*`, `$`, backticks, etc.), STOP immediately:
-
-- Print: "Refusing to proceed: extracted issue ID `<ID>` contains unsafe characters. Expected `[A-Za-z0-9._-]+`."
-
-This is a hard guard: the ID is interpolated into `rm -rf <base>/issues/<ID>` in Step 4, and an unsanitized value (e.g. `..` or one with embedded path separators) could delete the wrong directory. Fail closed on any surprise.
+The `remove-issue-dir.sh` script enforces ID validation internally (regex `^[A-Za-z0-9][A-Za-z0-9._-]*$`, rejects `.` and `..`). The ID extracted above is passed verbatim to the script in Step 4; if invalid, the script exits with a clear error and performs no deletion. No separate prose validation step is needed.
 
 ## Step 2: Check for Issue Directory
 
@@ -82,16 +78,16 @@ AskUserQuestion(
 
 ### Delete
 
-Only reached if the ID passed the whitelist check in Step 1. Do not run this step otherwise.
+Only reached if the user selected Delete in Step 3. The `remove-issue-dir.sh` script validates the ID, verifies the base path, checks that the resolved physical path stays under `<base>/issues/`, and performs the removal. No raw `rm -rf` is used.
 
 ```bash
-rm -rf <base>/issues/<ID>
+~/.claude/skills/cleanup-issue/remove-issue-dir.sh <base> <ID>
 ```
 
-Print:
+The script prints the removed path on stdout. Report that path to the user:
 
 ```text
-Cleaned up <base>/issues/<ID>/. All working files removed.
+Cleaned up <stdout>/. All working files removed.
 ```
 
 ## Step 5: Check for Side-Quest Artifacts

--- a/skills/cleanup-issue/remove-issue-dir.sh
+++ b/skills/cleanup-issue/remove-issue-dir.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# remove-issue-dir.sh — Safely remove an issue's working directory under
+# the shared .claude-work/ root.
+#
+# This is the ONLY code path that performs rm -rf in the cleanup-issue
+# workflow.  ID validation is enforced here, not in prose.
+#
+# Usage: remove-issue-dir.sh <base> <id>
+#
+#   <base>  Absolute path to .claude-work/ (from claude-work-root.sh)
+#   <id>    Issue ID validated against ^[A-Za-z0-9][A-Za-z0-9._-]*$
+#
+# Output (stdout):
+#   Absolute path removed (e.g., /Users/x/project/.claude-work/issues/42).
+#
+# Exit codes:
+#   0  — directory removed (or didn't exist — idempotent)
+#   1  — validation error (see stderr)
+#   2  — runtime error (see stderr)
+
+set -euo pipefail
+
+readonly ERR_BAD_ID="R001"
+readonly ERR_BAD_BASE="R002"
+readonly ERR_RM_FAILED="R003"
+
+# --- Validate arguments ---
+if [ $# -ne 2 ]; then
+  echo "remove-issue-dir $ERR_BAD_BASE error: usage: remove-issue-dir.sh <base> <id>" >&2
+  exit 1
+fi
+
+base="$1"
+id="$2"
+
+# --- Validate base ---
+# Must be an absolute path ending in .claude-work (belt-and-suspenders — the
+# only caller is claude-work-root.sh, but guard against accidents).
+# Check existence first so a non-existent directory surfaces clearly.
+if [ ! -d "$base" ]; then
+  echo "remove-issue-dir $ERR_BAD_BASE error: base directory does not exist: $base" >&2
+  exit 2
+fi
+
+if [[ "$base" != /* ]] || [[ "$base" != */.claude-work ]]; then
+  echo "remove-issue-dir $ERR_BAD_BASE error: base must be an absolute path ending in /.claude-work, got: $base" >&2
+  exit 1
+fi
+
+# --- Validate ID ---
+# Must start with alphanumeric (rejects . and ..) and contain only safe chars.
+if ! [[ "$id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  echo "remove-issue-dir $ERR_BAD_ID error: invalid issue ID '$id'. Expected ^[A-Za-z0-9][A-Za-z0-9._-]*\$" >&2
+  exit 1
+fi
+
+# --- Construct and verify target ---
+target="${base}/issues/${id}"
+
+# Resolve physical path to catch symlink-based escapes.
+# If the directory doesn't exist, resolve the longest existing prefix.
+target_physical="$(cd "$target" 2>/dev/null && pwd -P || true)"
+if [ -z "$target_physical" ]; then
+  # Directory doesn't exist — resolve the parent to check it's safe.
+  target_physical="$(cd "$(dirname "$target")" 2>/dev/null && pwd -P || true)"
+  if [ -z "$target_physical" ]; then
+    # Parent doesn't exist either.  Construct what it would be.
+    base_physical="$(cd "$base" 2>/dev/null && pwd -P)"
+    target_physical="${base_physical}/issues/${id}"
+  else
+    target_physical="${target_physical}/$(basename "$target")"
+  fi
+fi
+
+# Belt-and-suspenders: the resolved physical path must start with <base>/issues/.
+base_physical="$(cd "$base" 2>/dev/null && pwd -P)"
+expected_prefix="${base_physical}/issues/"
+
+if [[ "$target_physical" != "$expected_prefix"* ]]; then
+  echo "remove-issue-dir $ERR_BAD_ID error: resolved path '$target_physical' is not under '$expected_prefix'" >&2
+  exit 1
+fi
+
+# --- Remove ---
+if [ -d "$target" ]; then
+  if ! rm -rf "$target"; then
+    echo "remove-issue-dir $ERR_RM_FAILED error: failed to remove $target" >&2
+    exit 2
+  fi
+fi
+
+printf '%s\n' "$target"

--- a/skills/cleanup-issue/remove-issue-dir.sh
+++ b/skills/cleanup-issue/remove-issue-dir.sh
@@ -60,10 +60,10 @@ target="${base}/issues/${id}"
 
 # Resolve physical path to catch symlink-based escapes.
 # If the directory doesn't exist, resolve the longest existing prefix.
-target_physical="$(cd "$target" 2>/dev/null && pwd -P || true)"
+target_physical="$(if cd "$target" 2>/dev/null; then pwd -P; fi)"
 if [ -z "$target_physical" ]; then
   # Directory doesn't exist — resolve the parent to check it's safe.
-  target_physical="$(cd "$(dirname "$target")" 2>/dev/null && pwd -P || true)"
+  target_physical="$(if cd "$(dirname "$target")" 2>/dev/null; then pwd -P; fi)"
   if [ -z "$target_physical" ]; then
     # Parent doesn't exist either.  Construct what it would be.
     base_physical="$(cd "$base" 2>/dev/null && pwd -P)"

--- a/skills/create-github-issue/SKILL.md
+++ b/skills/create-github-issue/SKILL.md
@@ -3,7 +3,7 @@ name: create-github-issue
 version: 2026.06.25@7353cfe
 description: Create a GitHub issue from a file draft or inline description, with smart label discovery and sub-issue linking
 argument-hint: <file-path-or-title>
-allowed-tools: Read, Write, Glob, Bash(gh repo view *), Bash(gh label list *), Bash(gh issue create *), Bash(*/skills/create-github-issue/link-sub-issue.sh *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *)
+allowed-tools: Read, Write, Glob, Bash(gh repo view *), Bash(gh label list *), Bash(gh issue create *), Bash(*/skills/create-github-issue/link-sub-issue.sh *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Create GitHub Issue

--- a/skills/finish-issue/SKILL.md
+++ b/skills/finish-issue/SKILL.md
@@ -3,7 +3,7 @@ name: finish-issue
 version: 2026.06.25@7353cfe
 description: Wrap up issue or side-quest work on the current issues/* or side-quest/* branch. Runs verification, checks documentation needs, and generates a PR description
 argument-hint: [optional: issue-number-or-url]
-allowed-tools: Read, Write, Glob, Grep, AskUserQuestion, Bash(git branch --show-current), Bash(git status), Bash(git log *), Bash(git diff *), Bash(make lint-fix *), Bash(make test *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *)
+allowed-tools: Read, Write, Glob, Grep, AskUserQuestion, Bash(git branch --show-current), Bash(git status), Bash(git log *), Bash(git diff *), Bash(make lint-fix *), Bash(make test *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Finish Issue
@@ -38,10 +38,18 @@ Current branch: <branch>
 
 ## Step 1b: Resolve Active Plan
 
+First, resolve the `.claude-work/` root directory:
+
+```bash
+~/.claude/skills/issue-context/claude-work-root.sh
+```
+
+Use the stdout as `<base>` for all `.claude-work/` paths below. This script automatically detects git worktrees and returns the shared location.
+
 Read the active-plan pointer written by `/start-issue` or `/start-side-quest` to locate the primary working document:
 
-- **Issue mode:** read `.claude-work/issues/<ID>/active-plan`
-- **Side-quest mode:** read `.claude-work/active-plan-<slug>`
+- **Issue mode:** read `<base>/issues/<ID>/active-plan`
+- **Side-quest mode:** read `<base>/active-plan-<slug>`
 
 The pointer contents is a single project-root-relative path. Record it as the **resolved plan path**. This is the single source of truth for the primary plan.
 
@@ -129,15 +137,15 @@ Note whether a template was found and its path. This is used in Step 5. If none 
 
 **Issue mode (path differences):**
 
-- Breadcrumbs: `.claude-work/issues/<ID>/breadcrumb.md`
-- Auxiliary notes: `Glob(pattern="**/*", path=".claude-work/issues/<ID>/notes")` (excluding the resolved plan if it's a note)
-- Auxiliary scratchpads: `Glob(pattern="**/*", path=".claude-work/issues/<ID>/scratchpads")` (excluding the resolved plan if it's a scratchpad)
+- Breadcrumbs: `<base>/issues/<ID>/breadcrumb.md`
+- Auxiliary notes: `Glob(pattern="**/*", path="<base>/issues/<ID>/notes")` (excluding the resolved plan if it's a note)
+- Auxiliary scratchpads: `Glob(pattern="**/*", path="<base>/issues/<ID>/scratchpads")` (excluding the resolved plan if it's a scratchpad)
 
 **Side-quest mode (path differences):**
 
-- Breadcrumbs: `.claude-work/breadcrumb-<slug>.md`
-- Auxiliary notes: `Glob(pattern="*side-quest-<slug>*", path=".claude-work/notes")` (excluding the resolved plan)
-- Auxiliary scratchpads: `Glob(pattern="*side-quest-<slug>*", path=".claude-work/scratchpads")` (excluding the resolved plan)
+- Breadcrumbs: `<base>/breadcrumb-<slug>.md`
+- Auxiliary notes: `Glob(pattern="*side-quest-<slug>*", path="<base>/notes")` (excluding the resolved plan)
+- Auxiliary scratchpads: `Glob(pattern="*side-quest-<slug>*", path="<base>/scratchpads")` (excluding the resolved plan)
 
 ## Step 5: Generate PR Description Working Document
 

--- a/skills/issue-context/SKILL.md
+++ b/skills/issue-context/SKILL.md
@@ -2,13 +2,15 @@
 name: issue-context
 version: 2026.06.25@7353cfe
 user-invocable: false
-description: Contract for target-path.sh, the shell script that resolves .claude-work/ file paths from the current git branch. Referenced by name from /scratchpad, /question, /commit-msg; not auto-consulted.
-allowed-tools: Bash(*/skills/issue-context/target-path.sh *)
+description: Contract for target-path.sh and claude-work-root.sh, the shell scripts that resolve .claude-work/ file paths from the current git branch. Referenced by name from /scratchpad, /question, /commit-msg; not auto-consulted.
+allowed-tools: Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Issue Context
 
-All deterministic logic for "where should this file go?" lives in `target-path.sh`. Skills that write numbered working files call the script; nothing reasons about branch names in Markdown.
+All deterministic logic for "where should this file go?" lives in the scripts. Skills that write numbered working files call `target-path.sh`; skills that only need the `.claude-work/` root directory call `claude-work-root.sh`.
+
+## Script: target-path.sh
 
 ## Script contract
 
@@ -21,9 +23,21 @@ The script reads the current branch, extracts the issue ID (numeric prefix of th
 - On `issues/<ID>` branches: `.claude-work/issues/<ID>/<type>/NNNN-<slug>.<ext>`
 - Everywhere else: `.claude-work/<type>/NNNN-<slug>.<ext>`
 
+## Script: claude-work-root.sh
+
+```bash
+~/.claude/skills/issue-context/claude-work-root.sh
+```
+
+Returns the absolute path to the `.claude-work/` root directory, taking git worktrees into account. In the primary checkout `.claude-work/` lives at `--show-toplevel` (same as before). In a linked worktree (detected by comparing `--git-dir` against `--git-common-dir`), `.claude-work/` lives at the main checkout root so all worktrees share a single copy.
+
+The script outputs an absolute path on stdout (e.g., `/Users/x/project/.claude-work`). The directory is NOT created by this script — callers handle that.
+
+Skills that need the `.claude-work/` root but don't use `target-path.sh` (like `/note` and `/breadcrumb`) call this script directly to get the base directory, then append their subdirectory and filename.
+
 ## Breadcrumbs
 
-`/breadcrumb` writes to a single file per issue (not a numbered sequence), so it does not use `target-path.sh`. It detects the branch directly and writes to `.claude-work/issues/<ID>/breadcrumb.md` or `.claude-work/breadcrumb-<slug>.md`.
+`/breadcrumb` writes to a single file per issue (not a numbered sequence), so it does not use `target-path.sh`. It calls `claude-work-root.sh` to get the base directory, then writes to `<base>/issues/<ID>/breadcrumb.md` or `<base>/breadcrumb-<slug>.md`.
 
 ## History
 

--- a/skills/issue-context/claude-work-root.sh
+++ b/skills/issue-context/claude-work-root.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# claude-work-root.sh — Returns the absolute path to the .claude-work/
+# root directory, taking git worktrees into account.
+#
+# In the primary checkout, .claude-work/ lives at --show-toplevel (same
+# behavior as before).  In a linked worktree, .claude-work/ lives at the
+# main checkout root (one level above --git-common-dir) so all worktrees
+# of the same repo share a single copy.
+#
+# Usage: claude-work-root.sh
+#
+# Output (single line on stdout):
+#   Absolute path to .claude-work/ (e.g., /Users/x/project/.claude-work).
+#   The directory is NOT created — callers handle that.
+#
+# Exit codes:
+#   0  — success
+#   1  — error (see stderr)
+
+set -euo pipefail
+
+readonly ERR_NOT_GIT="C001"
+readonly ERR_NO_TOLEVEL="C002"
+
+# --- Resolve repo root (physical path, no symlinks or ..) ---
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "claude-work-root $ERR_NOT_GIT error: not in a git repository" >&2
+  exit 1
+}
+
+[ -n "$repo_root" ] || {
+  echo "claude-work-root $ERR_NO_TOLEVEL error: could not resolve --show-toplevel" >&2
+  exit 1
+}
+
+# Canonicalise — --show-toplevel may preserve symlinks (macOS /var vs /private/var).
+repo_root="$(cd "$repo_root" && pwd -P)"
+
+# --- Resolve a git-rev-parse path to an absolute path ---
+# Paths from --git-dir / --git-common-dir are relative to --show-toplevel
+# when inside the repo (or absolute on newer git).  Normalise both cases.
+resolve_abs() {
+  local p="$1"
+  if [[ "$p" == /* ]]; then
+    printf '%s\n' "$p"
+  else
+    printf '%s/%s\n' "$repo_root" "$p"
+  fi
+}
+
+# --- Detect linked worktree ---
+# --git-dir and --git-common-dir may be relative to CWD (e.g. ../.git from a
+# subdirectory).  Resolve both to physical paths so string comparison works.
+git_dir_raw="$(git rev-parse --git-dir 2>/dev/null)"
+git_common_dir_raw="$(git rev-parse --git-common-dir 2>/dev/null)"
+
+git_dir_abs="$(cd "$(resolve_abs "$git_dir_raw")" 2>/dev/null && pwd -P || true)"
+git_common_dir_abs="$(cd "$(resolve_abs "$git_common_dir_raw")" 2>/dev/null && pwd -P || true)"
+
+if [ -z "$git_dir_abs" ] || [ -z "$git_common_dir_abs" ]; then
+  # Fallback: if resolution failed, assume primary checkout.
+  main_root="$repo_root"
+elif [ "$git_dir_abs" != "$git_common_dir_abs" ]; then
+  # Linked worktree: place .claude-work at the main checkout root.
+  # git-common-dir is the shared .git directory; the main checkout is its parent.
+  main_root="$(dirname "$git_common_dir_abs")"
+else
+  # Primary checkout: .claude-work lives alongside the working tree.
+  main_root="$repo_root"
+fi
+
+printf '%s/.claude-work\n' "$main_root"

--- a/skills/issue-context/claude-work-root.sh
+++ b/skills/issue-context/claude-work-root.sh
@@ -38,14 +38,15 @@ repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
 repo_root="$(cd "$repo_root" && pwd -P)"
 
 # --- Resolve a git-rev-parse path to an absolute path ---
-# Paths from --git-dir / --git-common-dir are relative to --show-toplevel
-# when inside the repo (or absolute on newer git).  Normalise both cases.
+# --git-dir / --git-common-dir are relative to CWD (or absolute on newer git).
+# Resolve relative paths against $PWD so nested invocations point at the correct
+# git directories regardless of where the script was invoked from.
 resolve_abs() {
   local p="$1"
   if [[ "$p" == /* ]]; then
     printf '%s\n' "$p"
   else
-    printf '%s/%s\n' "$repo_root" "$p"
+    printf '%s/%s\n' "$PWD" "$p"
   fi
 }
 
@@ -55,8 +56,12 @@ resolve_abs() {
 git_dir_raw="$(git rev-parse --git-dir 2>/dev/null)"
 git_common_dir_raw="$(git rev-parse --git-common-dir 2>/dev/null)"
 
-git_dir_abs="$(cd "$(resolve_abs "$git_dir_raw")" 2>/dev/null && pwd -P || true)"
-git_common_dir_abs="$(cd "$(resolve_abs "$git_common_dir_raw")" 2>/dev/null && pwd -P || true)"
+if ! git_dir_abs="$(cd "$(resolve_abs "$git_dir_raw")" 2>/dev/null && pwd -P)"; then
+  git_dir_abs=""
+fi
+if ! git_common_dir_abs="$(cd "$(resolve_abs "$git_common_dir_raw")" 2>/dev/null && pwd -P)"; then
+  git_common_dir_abs=""
+fi
 
 if [ -z "$git_dir_abs" ] || [ -z "$git_common_dir_abs" ]; then
   # Fallback: if resolution failed, assume primary checkout.

--- a/skills/issue-context/target-path.sh
+++ b/skills/issue-context/target-path.sh
@@ -128,15 +128,23 @@ if [[ "$branch" == issues/* ]]; then
   fi
 fi
 
-# --- Anchor to repo root so all paths are resolved relative to it, not CWD ---
-repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"
-[ -n "$repo_root" ] && cd "$repo_root"
+# --- Resolve script directory early (needed for sibling scripts) ---
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Resolve .claude-work root (worktree-aware) ---
+# In the primary checkout this is <repo-root>/.claude-work; in a linked
+# worktree it is the main checkout's .claude-work, so all worktrees share
+# a single copy.
+claude_work_root="$("${script_dir}/claude-work-root.sh")" || {
+  echo "target-path $ERR_BRANCH_DETECT error: claude-work-root.sh failed" >&2
+  exit 1
+}
 
 # --- Determine target directory ---
 if [ -n "$issue_id" ]; then
-  target_dir=".claude-work/issues/${issue_id}/${type_arg}"
+  target_dir="${claude_work_root}/issues/${issue_id}/${type_arg}"
 else
-  target_dir=".claude-work/${type_arg}"
+  target_dir="${claude_work_root}/${type_arg}"
 fi
 
 # --- Slugify description ---
@@ -151,7 +159,6 @@ if [ -z "$slug" ]; then
 fi
 
 # --- Get next sequence number via auto-number ---
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 auto_number_script="${script_dir}/../auto-number/auto-number.sh"
 
 if [ ! -x "$auto_number_script" ]; then

--- a/skills/note/SKILL.md
+++ b/skills/note/SKILL.md
@@ -3,7 +3,7 @@ name: note
 version: 2026.06.25@7353cfe
 description: Capture a quick note, finding, or result in a timestamped file under .claude-work/. Lightweight alternative to /scratchpad with no foundation skill dependencies
 argument-hint: <description>
-allowed-tools: Read, Write, Glob, Bash(git branch --show-current), Bash(mkdir -p *), Bash(date *)
+allowed-tools: Read, Write, Glob, Bash(git branch --show-current), Bash(mkdir -p *), Bash(date *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Note
@@ -14,7 +14,11 @@ Capture a note, finding, or result in a lightweight timestamped file. Use this i
 
 ## Step 1: Determine Target Directory and Timestamp
 
-Run both commands as parallel tool calls. They are independent:
+Run these three commands as parallel tool calls. They are independent:
+
+```bash
+~/.claude/skills/issue-context/claude-work-root.sh
+```
 
 ```bash
 git branch --show-current
@@ -24,10 +28,12 @@ git branch --show-current
 date +%Y%m%d-%H%M%S
 ```
 
+Use the stdout of `claude-work-root.sh` as the base path (e.g., `/Users/x/project/.claude-work`). This script automatically detects git worktrees and returns the shared `.claude-work/` location.
+
 If the branch starts with `issues/`, extract the issue number (characters after `issues/` up to the first `-` or `_`, only if those characters are purely numeric; otherwise use the full string after `issues/`):
 
-- **On an issue branch:** `.claude-work/issues/<ID>/notes/`
-- **Otherwise:** `.claude-work/notes/`
+- **On an issue branch:** `<base>/issues/<ID>/notes/`
+- **Otherwise:** `<base>/notes/`
 
 Create the directory if it doesn't exist:
 

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -3,7 +3,7 @@ name: start-issue
 version: 2026.06.25@7353cfe
 description: Start working on a GitHub issue - analyze, explore codebase, and create detailed implementation plan
 argument-hint: <github-issue-url> [--scratchpad]
-allowed-tools: Read, Write, Glob, Grep, Bash(git branch --show-current), Bash(git fetch *), Bash(git checkout *), Bash(gh issue view *), Bash(gh issue edit * --add-assignee *), Bash(gh api graphql *), Bash(gh issue comment *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/start-issue/update-project-status.sh *)
+allowed-tools: Read, Write, Glob, Grep, Bash(git branch --show-current), Bash(git fetch *), Bash(git checkout *), Bash(gh issue view *), Bash(gh issue edit * --add-assignee *), Bash(gh api graphql *), Bash(gh issue comment *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *), Bash(*/skills/start-issue/update-project-status.sh *)
 ---
 
 # Start Issue
@@ -14,7 +14,17 @@ Analyze a GitHub issue, explore the codebase, and create a detailed implementati
 
 ## Step 0: Clean Up Current Issue Artifacts
 
-Before starting new work, run `git branch --show-current` to detect whether the current branch is `issues/<ID>`. If so, extract the ID (numeric prefix before the first `-`/`_`, or the full segment after `issues/`) and use `Glob(pattern="*", path=".claude-work/issues/<ID>")` to check whether the issue's working directory has contents. If the directory exists and has files, invoke `/cleanup-issue` to offer cleanup of that specific directory. Other issue directories are left untouched. The user may return to them later.
+Run both commands as parallel tool calls:
+
+```bash
+git branch --show-current
+```
+
+```bash
+~/.claude/skills/issue-context/claude-work-root.sh
+```
+
+Use the stdout of `claude-work-root.sh` as `<base>` for all `.claude-work/` paths in this skill. Detect whether the current branch is `issues/<ID>`. If so, extract the ID (numeric prefix before the first `-`/`_`, or the full segment after `issues/`) and use `Glob(pattern="*", path="<base>/issues/<ID>")` to check whether the issue's working directory has contents. If the directory exists and has files, invoke `/cleanup-issue` to offer cleanup of that specific directory. Other issue directories are left untouched. The user may return to them later.
 
 **If no issue context on the current branch, or the directory doesn't exist or is empty:** proceed directly to Step 1.
 
@@ -117,7 +127,7 @@ Use `/scratchpad` with description `start-issue-plan`. The scratchpad uses the s
 
 After the working document is created (via either path), write the pointer file so `/finish-issue` and `/tackle-scratchpad-block` can resolve the primary plan without guessing:
 
-**Path:** `.claude-work/issues/<NUMBER>/active-plan`
+**Path:** `<base>/issues/<NUMBER>/active-plan` (where `<base>` is from Step 0)
 
 **Contents:** the project-root-relative path to the working document (a single line, no trailing newline required), for example:
 
@@ -191,7 +201,7 @@ Before finishing, verify:
 
 - [ ] Feature branch `issues/<NUMBER>` was created
 - [ ] Working document created via `/note` (default) or `/scratchpad` (opt-in), not both
-- [ ] `.claude-work/issues/<NUMBER>/active-plan` pointer written with the project-root-relative path to the working document
+- [ ] `<base>/issues/<NUMBER>/active-plan` pointer written with the project-root-relative path to the working document
 - [ ] Plan has specific file/function names (not "update the code")
 - [ ] Each step is small enough to be one commit
 - [ ] Test updates are mentioned for each step that changes behavior

--- a/skills/start-side-quest/SKILL.md
+++ b/skills/start-side-quest/SKILL.md
@@ -3,7 +3,7 @@ name: start-side-quest
 version: 2026.06.25@7353cfe
 description: Start a side-quest branch for orthogonal improvements discovered while working on an issue
 argument-hint: <description | path/to/file.ts#L10-L20> [--scratchpad]
-allowed-tools: Read, Write, Glob, Grep, Bash(git fetch *), Bash(git checkout *), Bash(git branch --show-current), Bash(git status *), Bash(git stash *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *)
+allowed-tools: Read, Write, Glob, Grep, Bash(git fetch *), Bash(git checkout *), Bash(git branch --show-current), Bash(git status *), Bash(git stash *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Start Side-Quest
@@ -64,7 +64,7 @@ Choose the working-document type based on whether formal step tracking is reques
 - **Default (`/note`):** use this unless the user explicitly opted in. Produces a lightweight, freeform plan. Relies on you (the LLM) to self-organize execution in-session.
 - **Opt-in (`/scratchpad`):** triggered when `$ARGUMENTS` contains `--scratchpad`, or when the user's invoking message contains a natural-language opt-in phrase ("use a scratchpad", "with step tracking", "formal plan", "track steps"). Produces a scratchpad with a JSON step block so `/tackle-scratchpad-block` can drive execution.
 
-Side-quest branches don't match `issues/*`, so the working document lands in the flat `.claude-work/notes/` (default) or `.claude-work/scratchpads/` (opt-in) directory.
+Side-quest branches don't match `issues/*`, so the working document lands in the flat `<base>/notes/` (default) or `<base>/scratchpads/` (opt-in) directory, where `<base>` is the output of `~/.claude/skills/issue-context/claude-work-root.sh`.
 
 ### 3a. Default path: `/note`
 
@@ -92,7 +92,7 @@ Use `/scratchpad` with description `side-quest-<slug>`. Same sections as 3a, exc
 
 After the working document is created (via either path), write the pointer file so `/finish-issue` and `/tackle-scratchpad-block` can resolve the primary plan:
 
-**Path:** `.claude-work/active-plan-<slug>`
+**Path:** `<base>/active-plan-<slug>` (where `<base>` is from `claude-work-root.sh`)
 
 **Contents:** the project-root-relative path to the working document, for example:
 
@@ -121,10 +121,10 @@ Branch: side-quest/<slug>
 Parent: <original branch> (stashed if had changes)
 
 Files created:
-- .claude-work/notes/<file>.txt (implementation plan, default path)
-  OR .claude-work/scratchpads/<file>.txt (if --scratchpad)
-- .claude-work/active-plan-<slug> (pointer to the working document)
-- .claude-work/questions/<file>.txt (if questions needed)
+- <base>/notes/<file>.txt (implementation plan, default path)
+  OR <base>/scratchpads/<file>.txt (if --scratchpad)
+- <base>/active-plan-<slug> (pointer to the working document)
+- <base>/questions/<file>.txt (if questions needed)
 
 Stash: <stash message if applicable>
 
@@ -151,7 +151,7 @@ Before finishing, verify:
 - [ ] Current work stashed (if on a work branch with changes)
 - [ ] Side-quest branch created from `<base-branch>`
 - [ ] Working document created via `/note` (default) or `/scratchpad` (opt-in). Not both
-- [ ] `.claude-work/active-plan-<slug>` pointer written with the project-root-relative path to the working document
+- [ ] `<base>/active-plan-<slug>` pointer written with the project-root-relative path to the working document
 - [ ] Plan has specific file/change details
 - [ ] Parent branch noted for easy return
 

--- a/skills/tackle-pr-comment/SKILL.md
+++ b/skills/tackle-pr-comment/SKILL.md
@@ -3,7 +3,7 @@ name: tackle-pr-comment
 version: 2026.06.25@7353cfe
 description: Tackle a PR comment - analyze feedback, explore code, and create implementation working document
 argument-hint: <pr-comment-url> [--scratchpad]
-allowed-tools: Read, Glob, Grep, Write, Bash(gh api repos/*/*/pulls/*/reviews/*), Bash(gh api repos/*/*/pulls/comments/*), Bash(gh api repos/*/*/issues/comments/*), Bash(gh api repos/*/*/pulls/*/comments*), Bash(gh api repos/*/*/issues/*/comments*), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *)
+allowed-tools: Read, Glob, Grep, Write, Bash(gh api repos/*/*/pulls/*/reviews/*), Bash(gh api repos/*/*/pulls/comments/*), Bash(gh api repos/*/*/issues/comments/*), Bash(gh api repos/*/*/pulls/*/comments*), Bash(gh api repos/*/*/issues/*/comments*), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Tackle PR Comment

--- a/skills/tackle-scratchpad-block/SKILL.md
+++ b/skills/tackle-scratchpad-block/SKILL.md
@@ -12,7 +12,7 @@ Execute a specific block of implementation steps from a scratchpad file, then cr
 
 **Note on `Bash(*)` permission:** This skill intentionally uses unrestricted Bash access because it executes arbitrary implementation steps and test suites from user-authored scratchpad content. Other skills use allowlisted commands for their specific workflows. Users should review scratchpad content before invoking this skill.
 
-**Input:** $ARGUMENTS (a code reference to scratchpad lines, e.g. `.claude-work/issues/70/scratchpads/0001-plan.txt#L25-L67` or `path/to/plan.txt#S003`)
+**Input:** $ARGUMENTS (a code reference to scratchpad lines, e.g. `/Users/x/project/.claude-work/issues/70/scratchpads/0001-plan.txt#L25-L67` or `path/to/plan.txt#S003`)
 
 ## Step 0: Resolve Active Plan and Sanity-Check
 
@@ -20,7 +20,7 @@ Determine the file the user's argument points at (the path portion before `#S00N
 
 **If the argument resolves to a file containing a JSON step block:** proceed normally to Step 1. The explicit argument always takes precedence. The active-plan pointer is not consulted.
 
-**If the argument does NOT resolve to a JSON step block** (file not found, or file exists but has no `"steps"` array): read the active-plan pointer (issue mode: `.claude-work/issues/<ID>/active-plan`; side-quest mode: `.claude-work/active-plan-<slug>`) to name the resolved path in the guidance message; if the pointer file is missing or empty, use `(no active-plan pointer found)` as the resolved path. Then STOP:
+**If the argument does NOT resolve to a JSON step block** (file not found, or file exists but has no `"steps"` array): resolve `<base>` via `~/.claude/skills/issue-context/claude-work-root.sh`, then read the active-plan pointer (issue mode: `<base>/issues/<ID>/active-plan`; side-quest mode: `<base>/active-plan-<slug>`) to name the resolved path in the guidance message; if the pointer file is missing or empty, use `(no active-plan pointer found)` as the resolved path. Then STOP:
 
 ```text
 This skill drives execution against a JSON step block, but the working document at

--- a/tests/note.bats
+++ b/tests/note.bats
@@ -73,7 +73,7 @@ SKILL="$PROJECT_ROOT/skills/note/SKILL.md"
 }
 
 @test "note skill: routes to <base>/issues/<ID>/notes/ on issue branches" {
-  grep -q 'issues/.*notes/' "$SKILL"
+  grep -q '<base>/issues/.*notes/' "$SKILL"
 }
 
 @test "note skill: routes to <base>/notes/ as fallback" {

--- a/tests/note.bats
+++ b/tests/note.bats
@@ -36,8 +36,8 @@ SKILL="$PROJECT_ROOT/skills/note/SKILL.md"
 # Self-contained: no foundation skill cross-references
 # =============================================================
 
-@test "note skill: does not cross-reference /issue-context" {
-  ! grep -q "/issue-context" "$SKILL"
+@test "note skill: references issue-context scripts for path resolution" {
+  grep -q "issue-context/claude-work-root.sh" "$SKILL"
 }
 
 @test "note skill: does not cross-reference /auto-number" {
@@ -72,12 +72,12 @@ SKILL="$PROJECT_ROOT/skills/note/SKILL.md"
   grep -q "git branch --show-current" "$SKILL"
 }
 
-@test "note skill: routes to .claude-work/issues/<ID>/notes/ on issue branches" {
-  grep -q '\.claude-work/issues/.*notes/' "$SKILL"
+@test "note skill: routes to <base>/issues/<ID>/notes/ on issue branches" {
+  grep -q 'issues/.*notes/' "$SKILL"
 }
 
-@test "note skill: routes to .claude-work/notes/ as fallback" {
-  grep -q '\.claude-work/notes/' "$SKILL"
+@test "note skill: routes to <base>/notes/ as fallback" {
+  grep -q '<base>/notes/' "$SKILL"
 }
 
 @test "note skill: uses .txt extension" {

--- a/tests/remove-issue-dir.bats
+++ b/tests/remove-issue-dir.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+#
+# Tests for skills/cleanup-issue/remove-issue-dir.sh — safely removes an
+# issue's working directory after validating the ID and base path.
+
+load test_helper
+
+SCRIPT="$PROJECT_ROOT/skills/cleanup-issue/remove-issue-dir.sh"
+
+setup() {
+  TEST_TEMP_DIR="$(mktemp -d)"
+  TEST_TEMP_DIR="$(cd "$TEST_TEMP_DIR" && pwd -P)"
+  # Create a realistic .claude-work/issues/ directory tree.
+  mkdir -p "$TEST_TEMP_DIR/.claude-work/issues"
+  BASE="$TEST_TEMP_DIR/.claude-work"
+}
+
+teardown() {
+  rm -rf "${TEST_TEMP_DIR:?}"
+}
+
+# ============================================================================
+# Usage errors
+# ============================================================================
+
+@test "missing arguments prints usage error" {
+  run "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R002"* ]]
+}
+
+@test "single argument prints usage error" {
+  run "$SCRIPT" "$BASE"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R002"* ]]
+}
+
+# ============================================================================
+# Base validation
+# ============================================================================
+
+@test "rejects base that doesn't end in /.claude-work" {
+  mkdir -p "$TEST_TEMP_DIR/somewhere"
+  run "$SCRIPT" "$TEST_TEMP_DIR/somewhere" "42"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R002"* ]]
+}
+
+@test "rejects relative base path" {
+  # Create a directory at the relative path so the existence check passes.
+  mkdir -p "$TEST_TEMP_DIR/not-claude-work"
+  cd "$TEST_TEMP_DIR"
+  run "$SCRIPT" "not-claude-work" "42"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R002"* ]]
+}
+
+@test "rejects non-existent base directory" {
+  run "$SCRIPT" "$TEST_TEMP_DIR/.claude-work-nonexistent" "42"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"R002"* ]]
+}
+
+# ============================================================================
+# ID validation
+# ============================================================================
+
+@test "rejects dot-only ID (.)" {
+  run "$SCRIPT" "$BASE" "."
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R001"* ]]
+}
+
+@test "rejects dot-dot ID (..)" {
+  run "$SCRIPT" "$BASE" ".."
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R001"* ]]
+}
+
+@test "rejects ID with slash" {
+  run "$SCRIPT" "$BASE" "foo/bar"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R001"* ]]
+}
+
+@test "rejects ID with space" {
+  run "$SCRIPT" "$BASE" "foo bar"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R001"* ]]
+}
+
+@test "rejects ID starting with hyphen" {
+  run "$SCRIPT" "$BASE" "-foo"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R001"* ]]
+}
+
+@test "rejects ID with shell metacharacters" {
+  run "$SCRIPT" "$BASE" '$(whoami)'
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R001"* ]]
+}
+
+@test "rejects empty ID" {
+  run "$SCRIPT" "$BASE" ""
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R001"* ]]
+}
+
+# ============================================================================
+# Successful removals
+# ============================================================================
+
+@test "removes existing issue directory and prints path" {
+  mkdir -p "$BASE/issues/42/scratchpads"
+  touch "$BASE/issues/42/scratchpads/0001-plan.txt"
+  [ -d "$BASE/issues/42" ]
+
+  run "$SCRIPT" "$BASE" "42"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$BASE/issues/42" ]
+  [ ! -d "$BASE/issues/42" ]
+}
+
+@test "idempotent: succeeds when issue directory does not exist" {
+  [ ! -d "$BASE/issues/99" ]
+
+  run "$SCRIPT" "$BASE" "99"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$BASE/issues/99" ]
+}
+
+@test "accepts alphanumeric and dot-hyphen IDs" {
+  mkdir -p "$BASE/issues/rfc-auth-v2.test/notes"
+  [ -d "$BASE/issues/rfc-auth-v2.test" ]
+
+  run "$SCRIPT" "$BASE" "rfc-auth-v2.test"
+  [ "$status" -eq 0 ]
+  [ ! -d "$BASE/issues/rfc-auth-v2.test" ]
+}
+
+# ============================================================================
+# Path traversal guard
+# ============================================================================
+
+@test "rejects ID that would escape via physical path" {
+  # Create a symlink outside the .claude-work tree that points back in.
+  mkdir -p "$TEST_TEMP_DIR/outside"
+  ln -s "$TEST_TEMP_DIR/outside" "$BASE/issues/escape-hatch"
+
+  run "$SCRIPT" "$BASE" "escape-hatch"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"R001"* ]]
+}

--- a/tests/remove-issue-dir.bats
+++ b/tests/remove-issue-dir.bats
@@ -130,6 +130,17 @@ teardown() {
   [ "$output" = "$BASE/issues/99" ]
 }
 
+@test "idempotent: succeeds when issues/ parent directory does not exist" {
+  # Simulates a .claude-work/ with no issues/ subdirectory at all.
+  # The script must resolve the physical path from the base directory.
+  rm -rf "$BASE/issues"
+  [ ! -d "$BASE/issues" ]
+
+  run "$SCRIPT" "$BASE" "42"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$BASE/issues/42" ]
+}
+
 @test "accepts alphanumeric and dot-hyphen IDs" {
   mkdir -p "$BASE/issues/rfc-auth-v2.test/notes"
   [ -d "$BASE/issues/rfc-auth-v2.test" ]

--- a/tests/target-path.bats
+++ b/tests/target-path.bats
@@ -222,6 +222,22 @@ teardown() {
 }
 
 # ============================================================================
+# Linked worktree: output resolves to main checkout, not worktree local
+# ============================================================================
+
+@test "linked worktree: output resolves to main checkout .claude-work" {
+  # Main checkout stays on the default branch; create a linked worktree
+  # on issues/99 so the branch is not already checked out.
+  git worktree add "$TEST_TEMP_DIR/wt-linked" -b issues/99 -q
+  cd "$TEST_TEMP_DIR/wt-linked"
+  run "$SCRIPT" --type notes --description "from worktree"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/issues/99/notes/0001-from-worktree.txt" ]
+  # Worktree directory should NOT have its own .claude-work
+  [ ! -d "$TEST_TEMP_DIR/wt-linked/.claude-work" ]
+}
+
+# ============================================================================
 # Repo-root anchoring: output is an absolute path independent of CWD
 # ============================================================================
 

--- a/tests/target-path.bats
+++ b/tests/target-path.bats
@@ -11,6 +11,9 @@ SCRIPT="$PROJECT_ROOT/skills/issue-context/target-path.sh"
 # Run the script inside a fresh git repo so branch detection is deterministic.
 setup() {
   TEST_TEMP_DIR="$(mktemp -d)"
+  # Resolve any symlinks (macOS /var → /private/var) so path comparisons
+  # against git rev-parse --show-toplevel output match exactly.
+  TEST_TEMP_DIR="$(cd "$TEST_TEMP_DIR" && pwd -P)"
   cd "$TEST_TEMP_DIR"
   git init -q
   git config user.email "test@example.com"
@@ -30,28 +33,28 @@ teardown() {
   git checkout -q -b issues/42
   run "$SCRIPT" --type scratchpads --description "Plan the refactor"
   [ "$status" -eq 0 ]
-  [ "$output" = ".claude-work/issues/42/scratchpads/0001-plan-the-refactor.txt" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/issues/42/scratchpads/0001-plan-the-refactor.txt" ]
 }
 
 @test "issues/120-extract-numeric-prefix → extracts 120" {
   git checkout -q -b issues/120-audit-cleanup
   run "$SCRIPT" --type questions --description "Scope question"
   [ "$status" -eq 0 ]
-  [ "$output" = ".claude-work/issues/120/questions/0001-scope-question.txt" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/issues/120/questions/0001-scope-question.txt" ]
 }
 
 @test "issues/120_with_underscore → extracts 120" {
   git checkout -q -b issues/120_audit
   run "$SCRIPT" --type scratchpads --description "Test"
   [ "$status" -eq 0 ]
-  [ "$output" = ".claude-work/issues/120/scratchpads/0001-test.txt" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/issues/120/scratchpads/0001-test.txt" ]
 }
 
 @test "issues/rfc-auth → non-numeric prefix uses full segment" {
   git checkout -q -b issues/rfc-auth
   run "$SCRIPT" --type commit-msgs --description "Draft message"
   [ "$status" -eq 0 ]
-  [ "$output" = ".claude-work/issues/rfc-auth/commit-msgs/0001-draft-message.txt" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/issues/rfc-auth/commit-msgs/0001-draft-message.txt" ]
 }
 
 # ============================================================================
@@ -64,14 +67,14 @@ teardown() {
   git checkout -q -B main
   run "$SCRIPT" --type scratchpads --description "Hello world"
   [ "$status" -eq 0 ]
-  [ "$output" = ".claude-work/scratchpads/0001-hello-world.txt" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/scratchpads/0001-hello-world.txt" ]
 }
 
 @test "side-quest/foo branch → flat-root placement" {
   git checkout -q -b side-quest/foo
   run "$SCRIPT" --type questions --description "Side quest question"
   [ "$status" -eq 0 ]
-  [ "$output" = ".claude-work/questions/0001-side-quest-question.txt" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/questions/0001-side-quest-question.txt" ]
 }
 
 # ============================================================================
@@ -81,11 +84,11 @@ teardown() {
 @test "second call increments NNNN" {
   git checkout -q -b issues/42
   run "$SCRIPT" --type scratchpads --description "First"
-  [ "$output" = ".claude-work/issues/42/scratchpads/0001-first.txt" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/issues/42/scratchpads/0001-first.txt" ]
   # Create the file so auto-number sees it on the next call
   touch ".claude-work/issues/42/scratchpads/0001-first.txt"
   run "$SCRIPT" --type scratchpads --description "Second"
-  [ "$output" = ".claude-work/issues/42/scratchpads/0002-second.txt" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/issues/42/scratchpads/0002-second.txt" ]
 }
 
 # ============================================================================
@@ -96,14 +99,14 @@ teardown() {
   git checkout -q -b issues/42
   run "$SCRIPT" --type scratchpads --description "Some   MIXED--Case & punctuation!"
   [ "$status" -eq 0 ]
-  [ "$output" = ".claude-work/issues/42/scratchpads/0001-some-mixed-case-punctuation.txt" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/issues/42/scratchpads/0001-some-mixed-case-punctuation.txt" ]
 }
 
 @test "slug trims leading and trailing hyphens" {
   git checkout -q -b issues/42
   run "$SCRIPT" --type scratchpads --description "  hello world  "
   [ "$status" -eq 0 ]
-  [ "$output" = ".claude-work/issues/42/scratchpads/0001-hello-world.txt" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/issues/42/scratchpads/0001-hello-world.txt" ]
 }
 
 # ============================================================================
@@ -114,14 +117,14 @@ teardown() {
   git checkout -q -B main
   run "$SCRIPT" --type scratchpads --description "Config" --ext json
   [ "$status" -eq 0 ]
-  [ "$output" = ".claude-work/scratchpads/0001-config.json" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/scratchpads/0001-config.json" ]
 }
 
 @test "--ext md still works alongside json" {
   git checkout -q -B main
   run "$SCRIPT" --type scratchpads --description "Doc" --ext md
   [ "$status" -eq 0 ]
-  [ "$output" = ".claude-work/scratchpads/0001-doc.md" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/scratchpads/0001-doc.md" ]
 }
 
 # ============================================================================
@@ -196,14 +199,14 @@ teardown() {
   git checkout -q -b issues/42
   run "$SCRIPT" --type notes --description "Plan the work"
   [ "$status" -eq 0 ]
-  [ "$output" = ".claude-work/issues/42/notes/0001-plan-the-work.txt" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/issues/42/notes/0001-plan-the-work.txt" ]
 }
 
 @test "notes type on main branch → flat-root notes path" {
   git checkout -q -B main
   run "$SCRIPT" --type notes --description "Quick finding"
   [ "$status" -eq 0 ]
-  [ "$output" = ".claude-work/notes/0001-quick-finding.txt" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/notes/0001-quick-finding.txt" ]
 }
 
 @test "invalid --type errors with T100" {
@@ -219,15 +222,15 @@ teardown() {
 }
 
 # ============================================================================
-# Repo-root anchoring: output is relative to repo root, not CWD
+# Repo-root anchoring: output is an absolute path independent of CWD
 # ============================================================================
 
-@test "subdirectory CWD: output path is relative to repo root, not CWD" {
+@test "subdirectory CWD: output path is absolute, independent of CWD" {
   mkdir -p subdir
   cd subdir
   run "$SCRIPT" --type notes --description "from subdir"
   [ "$status" -eq 0 ]
-  [ "$output" = ".claude-work/notes/0001-from-subdir.txt" ]
+  [ "$output" = "$TEST_TEMP_DIR/.claude-work/notes/0001-from-subdir.txt" ]
   [ -d "$TEST_TEMP_DIR/.claude-work/notes" ]
   [ ! -d "$TEST_TEMP_DIR/subdir/.claude-work" ]
 }


### PR DESCRIPTION
## Summary

Skills now detect git worktrees and place `.claude-work/` artifacts at the main checkout root instead of the worktree root. This prevents duplicate artifacts when working across multiple worktrees of the same repo. A new `claude-work-root.sh` helper returns the absolute shared path, and all path-producing skills now output absolute paths to avoid ambiguity.

## Changes

- Added `skills/issue-context/claude-work-root.sh` — a new helper that returns the absolute `.claude-work/` root path, detecting linked git worktrees by comparing `--git-dir` against `--git-common-dir` (the stable shared anchor recommended in CodeRabbit's analysis). In a linked worktree, `.claude-work/` lives at the main checkout root so all worktrees share a single copy
- `target-path.sh` now calls `claude-work-root.sh` for its base directory instead of resolving relative to `--show-toplevel`, and outputs absolute paths instead of relative ones
- `note` and `breadcrumb` skills updated to call `claude-work-root.sh` for directory resolution rather than constructing `.claude-work/` paths inline from branch detection alone
- Reading skills (`finish-issue`, `cleanup-issue`, `start-issue`, `start-side-quest`, `tackle-scratchpad-block`) updated to resolve the shared `<base>` before accessing `.claude-work/` artifacts, preventing silent misses when CWD is a worktree and the artifacts are at the main checkout root
- `tackle-pr-comment` and `create-github-issue` allowed-tools updated to include `claude-work-root.sh`
- `issue-context/SKILL.md` now documents both scripts (`target-path.sh` and `claude-work-root.sh`) with their distinct contracts

## Key Discoveries

- `git rev-parse --git-common-dir` can return paths relative to CWD (e.g., `../.git` from a subdirectory), so string comparison against `--git-dir` is unreliable without first canonicalizing both paths to physical absolute form
- On macOS, `mktemp -d` returns paths under `/var` (a symlink to `/private/var`), while `git rev-parse --show-toplevel` may return the physical path — test assertions must normalize with `pwd -P` to match
- `.gitignore` is tracked by git and synchronizes across worktrees via commits, so `ensure-gitignore.sh` required no worktree-specific changes; the `.claude-work/` pattern applies at the repo root regardless of which worktree committed it

## Test Plan

- [x] All existing tests pass (186 tests)
- [x] New tests added for: worktree detection and absolute path output in `target-path.bats`; updated `note.bats` for `claude-work-root.sh` cross-reference
- [x] `make check` (lint + test) passes with 0 errors

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared working-file path resolution for linked git worktrees (absolute `.claude-work/` base), used across notes, breadcrumbs, and issue cleanup.
  * Introduced safer issue-directory removal with validation and idempotent deletes.

* **Bug Fixes**
  * Fixed artifact and pointer locations to consistently use the shared worktree base instead of relying on current checkout or working directory.

* **Documentation**
  * Updated working files guidance and skill docs to match the new shared `.claude-work/` layout and path rules.

* **Tests**
  * Strengthened path-resolution and cleanup tests, including linked worktree scenarios and safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->