### PR TITLE
[issues/178] Add `.claude/settings.json` and refresh `CLAUDE.md`

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "ask": ["Bash(./install.sh *)", "Bash(./setup.sh *)"]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ demo/__pycache__/
 
 .venv/
 
-.claude/
+.claude/*
+!.claude/settings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.07.02
+
+### Added
+
+- Added `.claude/settings.json` with `ask` permission guardrails for `install.sh` and `setup.sh` — Claude will prompt before running either script, since `install.sh` modifies `~/.claude/skills/` (global Claude config) and `setup.sh` installs system packages. Updated `.gitignore` with a negation pattern so the committed settings file is not blocked by the blanket `.claude/` ignore. ([issues/178](https://github.com/couimet/my-claude-skills/issues/178))
+
+### Changed
+
+- Refreshed `CLAUDE.md` with a Repository Layout section documenting `install.sh`, `setup.sh`, `demo/`, `docs/ADR/`, `scripts/stamp-skills.sh`, and the `versions.mk` include. ([issues/178](https://github.com/couimet/my-claude-skills/issues/178))
+
 ## 2026.06.25.1
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,19 @@ This file provides guidance for AI agents working inside the `my-claude-skills` 
 
 This repository is a collection of portable Claude Code skills. Each skill is a `SKILL.md` file inside a `skills/<name>/` directory. Skills are installed globally at `~/.claude/skills/` (via symlinks) and loaded by Claude Code when a user types `/skill-name`. The repo's goal is to encode repeatable workflows — issue triage, PR feedback, plan-driven implementation — as portable, composable instructions.
 
+## Repository Layout
+
+Beyond `skills/` (the core product), these top-level files and directories matter:
+
+| Path | What it is |
+| --- | --- |
+| `install.sh` | Creates symlinks from `~/.claude/skills/` to this repo's `skills/` directory. Must be run after adding a new skill so it gets a symlink. Idempotent — safe to run repeatedly. Touches the user's global Claude config, so it must never run without explicit user approval. |
+| `setup.sh` | Installs the brew prerequisites that `make lint` and `make test` depend on. One-time contributor setup. Touches the system outside the repo, so it must never run without explicit user approval. |
+| `Makefile` | Includes `versions.mk` to pin linter versions matching CI. See Development Commands below. |
+| `demo/` | Static site generator (`generate.py`, `templates/`, `static/`) for the project homepage. Also contains `real-life/` — actual workflow artifacts from past issues, used as reference examples in README. |
+| `docs/ADR/` | Architecture Decision Records. Read these to understand design rationale for skill extension hooks and other structural choices. |
+| `scripts/stamp-skills.sh` | Called by `make stamp`. Stamps `version:` into every `skills/*/SKILL.md` front matter. CI-only — never run locally. |
+
 ## Development Commands
 
 Run all commands from the project root.


### PR DESCRIPTION
## Summary

Adds project-level Claude Code guardrails so Claude prompts before running `install.sh` (modifies `~/.claude/skills/`) or `setup.sh` (installs system packages). Refreshes `CLAUDE.md` with a Repository Layout section that maps the full repo surface beyond `skills/`.

## Changes

- Added `.claude/settings.json` with `ask` permission rules for `install.sh` and `setup.sh` — Claude prompts the user before running either script, preventing silent modification of global config or system package state
- Refreshed `CLAUDE.md` with a Repository Layout section documenting `install.sh`, `setup.sh`, `demo/`, `docs/ADR/`, `scripts/stamp-skills.sh`, and the `versions.mk` Makefile include
- Updated `.gitignore` from blanket `.claude/` to `.claude/*` + `!.claude/settings.json` so the committed settings file is trackable while personal overrides (`settings.local.json`) stay ignored
- Documentation: CHANGELOG updated with `## 2026.07.02` entries

## Key Discoveries

- Git negation patterns don't work against directory ignores (`dir/`). Changing to `dir/*` + `!dir/file` allows selective re-inclusion while keeping the rest of the directory ignored. Applied here so `.claude/settings.json` is trackable while `.claude/settings.local.json` remains ignored.

## Test Plan

- [ ] All 204 existing tests pass
- [ ] No new tests needed (configuration-only change)
- [ ] Manual: verify `git add -n .claude/` only stages `settings.json`, not `settings.local.json`

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/178