### PR TITLE
[issues/184] Require absolute paths for generated file paths in terminal output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Contributors are encouraged to add a changelog entry with their PR, but it's not
 
 - Skill attribution footers on commit messages, PR descriptions, and GitHub issue bodies. Each footer names the skill, its version, and links back to this repo. `/commit-msg` uses a `Skill:` git trailer; `/finish-issue` and `/create-github-issue` use a markdown-linked prose line matching the harness convention. ([issues/181](https://github.com/couimet/my-claude-skills/issues/181))
 
+## 2026.07.10.1
+
+### Fixed
+
+- Relative path friction in skill terminal output. After the worktree-aware `.claude-work/` changes in [issues/173](https://github.com/couimet/my-claude-skills/issues/173), path-producing scripts correctly emit absolute paths but the SKILL.md prose described paths in relative form (`.claude-work/...`), which the LLM sometimes echoed back — producing paths that aren't CMD+CLICKable, especially in worktree setups where `.claude-work/` is at the main checkout root. All path-reporting instructions now require absolute paths, and `/prose-style`'s absolute-paths rule establishes this as a global convention. ([issues/184](https://github.com/couimet/my-claude-skills/issues/184))
+
 ## 2026.07.02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,8 @@ All ephemeral working files live under `.claude-work/` (git-ignored). Never comm
 
 **Git worktree sharing:** `.claude-work/` lives at the main checkout root (resolved by `skills/issue-context/claude-work-root.sh`). In the primary checkout this is `git rev-parse --show-toplevel` (unchanged from before). In a linked git worktree it is `dirname(git rev-parse --git-common-dir)` — the main checkout — so all worktrees of the same repo share a single `.claude-work/` copy. Skills that write `.claude-work/` files use absolute paths to avoid ambiguity about which worktree the files live in. Skills never edit source files outside the current worktree; the shared location is only for ephemeral working artifacts.
 
+**Always use absolute paths in terminal output:** When reporting a generated file path (notes, scratchpads, questions, commit messages, PR descriptions, breadcrumbs), always print the full absolute path. Absolute paths are CMD+CLICKable in the IDE and survive CWD changes. Relative paths (`.claude-work/...`) fail in worktree setups where the CWD differs from the project root. See `/prose-style` (absolute paths rule) for the full rule.
+
 **`install.sh` symlink rule:** `install.sh` creates symlinks from `~/.claude/skills/` to the main checkout's `skills/` directory — never to a worktree directory. The global skill install is shared across all worktrees, so the target is always the main checkout (e.g., `/Users/couimet/geek/my-claude-skills/skills/`).
 
 **Auto-numbering:** File sequence numbers (`NNNN`) are managed by `skills/auto-number/auto-number.sh`. Foundation skills call it automatically — don't reimplement the logic.

--- a/skills/commit-msg/SKILL.md
+++ b/skills/commit-msg/SKILL.md
@@ -38,7 +38,7 @@ Run these two commands as parallel tool calls. They are independent.
 ~/.claude/skills/ensure-gitignore/ensure-gitignore.sh
 ```
 
-Use the stdout of the first command as the full file path. The script handles branch detection, issue-ID extraction, directory creation, auto-numbering, and slug normalization in one call. On an `issues/<ID>` branch the output is `.claude-work/issues/<ID>/commit-msgs/NNNN-<slug>.txt`; otherwise `.claude-work/commit-msgs/NNNN-<slug>.txt`.
+Use the stdout of the first command as the full absolute file path. The script handles branch detection, issue-ID extraction, directory creation, auto-numbering, and slug normalization in one call. On an `issues/<ID>` branch the output is an absolute path ending in `/.claude-work/issues/<ID>/commit-msgs/NNNN-<slug>.txt`; otherwise an absolute path ending in `/.claude-work/commit-msgs/NNNN-<slug>.txt`.
 
 ## Complexity Assessment
 
@@ -169,5 +169,5 @@ Formatting: see `/prose-style` for hard-wrap and GitHub-reference rules.
 4. **Self-check for diff-relevance (Gate).** If a change, fix, or decision was discussed in the conversation but does NOT appear in the effective diff, it is not part of this change set. Remove it from this message. The message describes ONLY the changes visible in THIS diff.
 5. **Self-check for hard-wrapping.** Re-read the file you just wrote. For each paragraph in the body (text between blank lines, outside code blocks and the Benefits bullet list), verify it is a single continuous line. If you find a mid-sentence line break, rewrite that paragraph as one line. This check catches the most common failure. Always complete it. Also skim for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.
 Also verify the complete skill footer contract: the footer is the very last line of the file, is separated from the `Files:` line by exactly one blank line, contains no `Co-Authored-By` trailer anywhere in the file, and the version matches this SKILL.md's front matter `version:` field.
-6. Print the filepath in terminal
+6. Print the absolute filepath in terminal
 7. Do NOT run `git commit`. The user reviews and commits manually.

--- a/skills/finish-issue/SKILL.md
+++ b/skills/finish-issue/SKILL.md
@@ -238,7 +238,7 @@ Verification:
 - uncommitted changes: [none / list]
 
 Files created:
-- <actual-path-to-pr-description> (PR description)
+- <actual-absolute-path-to-pr-description> (PR description)
 
 ---
 
@@ -259,7 +259,7 @@ Verification:
 - uncommitted changes: [none / list]
 
 Files created:
-- <actual-path-to-pr-description> (PR description)
+- <actual-absolute-path-to-pr-description> (PR description)
 
 ---
 

--- a/skills/finish-issue/SKILL.md
+++ b/skills/finish-issue/SKILL.md
@@ -243,8 +243,8 @@ Files created:
 ---
 
 Ready for PR. Review the file and:
-1. Commit: git add -p && git commit -F <actual-path-to-pr-description>
-2. Push and create PR: gh pr create --title "..." --body-file <actual-path-to-pr-description>
+1. Commit: git add -p && git commit -F <actual-absolute-path-to-pr-description>
+2. Push and create PR: gh pr create --title "..." --body-file <actual-absolute-path-to-pr-description>
 3. Or ask Claude to create the PR
 ```
 
@@ -264,8 +264,8 @@ Files created:
 ---
 
 Ready for PR. Review the file and:
-1. Commit: git add -p && git commit -F <actual-path-to-pr-description>
-2. Push and create PR: gh pr create --title "..." --body-file <actual-path-to-pr-description>
+1. Commit: git add -p && git commit -F <actual-absolute-path-to-pr-description>
+2. Push and create PR: gh pr create --title "..." --body-file <actual-absolute-path-to-pr-description>
 3. Or ask Claude to create the PR
 ```
 

--- a/skills/issue-context/SKILL.md
+++ b/skills/issue-context/SKILL.md
@@ -18,10 +18,10 @@ All deterministic logic for "where should this file go?" lives in the scripts. S
 ~/.claude/skills/issue-context/target-path.sh --type <scratchpads|questions|commit-msgs|notes> --description "<text>" [--ext txt]
 ```
 
-The script reads the current branch, extracts the issue ID (numeric prefix of the segment after `issues/` when applicable, full segment otherwise, empty on non-issue branches), slugifies the description, runs `auto-number.sh` internally, creates the target directory, and prints the full file path on stdout.
+The script reads the current branch, extracts the issue ID (numeric prefix of the segment after `issues/` when applicable, full segment otherwise, empty on non-issue branches), slugifies the description, runs `auto-number.sh` internally, creates the target directory, and prints the absolute file path on stdout.
 
-- On `issues/<ID>` branches: `.claude-work/issues/<ID>/<type>/NNNN-<slug>.<ext>`
-- Everywhere else: `.claude-work/<type>/NNNN-<slug>.<ext>`
+- On `issues/<ID>` branches: absolute path ending in `.claude-work/issues/<ID>/<type>/NNNN-<slug>.<ext>`
+- Everywhere else: absolute path ending in `.claude-work/<type>/NNNN-<slug>.<ext>`
 
 ## Script: claude-work-root.sh
 

--- a/skills/note/SKILL.md
+++ b/skills/note/SKILL.md
@@ -70,7 +70,7 @@ Also skim for AI-writing tells: em dashes, filler phrases (in order to, due to t
 
 ## Step 4: Confirm
 
-Print only the filepath:
+Print only the absolute filepath:
 
 ```text
 <target-directory>/<filename>

--- a/skills/prose-style/SKILL.md
+++ b/skills/prose-style/SKILL.md
@@ -18,7 +18,7 @@ This applies to every file a skill produces: scratchpads, questions, commit mess
 
 ### Format Anchors
 
-Format: one continuous line per paragraph, no hard wrapping. Code references: path/to/file.ts#L10 (bare, never backtick-wrapped). GitHub references: full URL only.
+Format: one continuous line per paragraph, no hard wrapping. Code references: path/to/file.ts#L10 (bare in file content, never backtick-wrapped). GitHub references: full URL only. Generated file paths in terminal output: absolute only.
 
 ### Self-check before you finish
 
@@ -26,9 +26,9 @@ Before reporting a file path back to the user, re-read the file you just wrote. 
 
 Also skim for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.
 
-## Rule 2: Code references
+## Rule 2: Code references (in file content)
 
-Use GitHub-style permalink syntax so references become clickable in RangeLink and similar tools.
+Use GitHub-style permalink syntax so references become clickable in RangeLink and similar tools. This rule applies to code references written inside generated files (scratchpads, questions, commit messages, PR descriptions). It does NOT apply to terminal output reporting generated file paths — see Rule 4 for that.
 
 | Reference type | Syntax | Example |
 | --- | --- | --- |
@@ -59,6 +59,12 @@ gh repo view --json url -q .url
 ```
 
 Then append `/issues/{number}` or `/pull/{number}`.
+
+## Rule 4: Generated file paths in terminal output must be absolute
+
+When reporting a generated file path to the user (e.g., "Created: ...", "File: ...", "Breadcrumb dropped in ..."), always use the full absolute path. Absolute paths are clickable in terminal and IDE (CMD+CLICK). Relative paths (`.claude-work/...`) are not — they break when the current working directory differs from the project root, as happens in git worktrees where `.claude-work/` is at the main checkout root.
+
+This applies to every skill that prints a file path: notes, scratchpads, questions, commit messages, PR descriptions, breadcrumbs.
 
 ## What this replaces
 

--- a/skills/question/SKILL.md
+++ b/skills/question/SKILL.md
@@ -34,7 +34,7 @@ Run these two commands as parallel tool calls. They are independent.
 ~/.claude/skills/ensure-gitignore/ensure-gitignore.sh
 ```
 
-Use the stdout of the first command as the full file path. The script handles branch detection, issue-ID extraction, directory creation, auto-numbering, and slug normalization in one call. On an `issues/<ID>` branch the output is `.claude-work/issues/<ID>/questions/NNNN-<slug>.txt`; otherwise `.claude-work/questions/NNNN-<slug>.txt`.
+Use the stdout of the first command as the full absolute file path. The script handles branch detection, issue-ID extraction, directory creation, auto-numbering, and slug normalization in one call. On an `issues/<ID>` branch the output is an absolute path ending in `/.claude-work/issues/<ID>/questions/NNNN-<slug>.txt`; otherwise an absolute path ending in `/.claude-work/questions/NNNN-<slug>.txt`.
 
 ## File Format
 
@@ -107,7 +107,7 @@ See `/prose-style` for hard-wrap and GitHub-reference rules.
 
 1. Create the file with questions formatted as above
 2. **Self-check for hard-wrapping.** Re-read the file. For each Context, Recommendation, and option description, verify the text is a single continuous line. If you find a mid-sentence line break in any of those fields, rewrite as one line. Always complete this check. Also skim for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.
-3. Print ONLY the filepath in terminal. Nothing else.
+3. Print ONLY the absolute filepath in terminal. Nothing else.
 4. Wait for the user to edit answers in the file
 5. The file is the single source of truth. Read it back to get answers
 

--- a/skills/scratchpad/SKILL.md
+++ b/skills/scratchpad/SKILL.md
@@ -36,7 +36,7 @@ Run these two commands as parallel tool calls. They are independent.
 ~/.claude/skills/ensure-gitignore/ensure-gitignore.sh
 ```
 
-Use the stdout of the first command as the full file path. The script handles branch detection, issue-ID extraction, directory creation, auto-numbering, and slug normalization in one call. On an `issues/<ID>` branch the output is `.claude-work/issues/<ID>/scratchpads/NNNN-<slug>.txt`; otherwise `.claude-work/scratchpads/NNNN-<slug>.txt`.
+Use the stdout of the first command as the full absolute file path. The script handles branch detection, issue-ID extraction, directory creation, auto-numbering, and slug normalization in one call. On an `issues/<ID>` branch the output is an absolute path ending in `/.claude-work/issues/<ID>/scratchpads/NNNN-<slug>.txt`; otherwise an absolute path ending in `/.claude-work/scratchpads/NNNN-<slug>.txt`.
 
 ## File Format
 
@@ -101,7 +101,7 @@ Step-level fields (inside each `steps` entry):
 
 ## After writing: self-check for hard-wrapping
 
-Before reporting the filepath back to the user, re-read the scratchpad you just wrote. For each paragraph in the body (text between blank lines, outside code blocks, tables, and lists), verify it is a single continuous line. If you find a mid-sentence line break, rewrite that paragraph as one line. Always complete this check. Wrapped prose is the most common failure mode for skill-generated files.
+Before reporting the absolute filepath back to the user, re-read the scratchpad you just wrote. For each paragraph in the body (text between blank lines, outside code blocks, tables, and lists), verify it is a single continuous line. If you find a mid-sentence line break, rewrite that paragraph as one line. Always complete this check. Wrapped prose is the most common failure mode for skill-generated files.
 
 Also skim for AI-writing tells: em dashes, filler phrases (in order to, due to the fact that), vague attributions, generic positive conclusions. Rewrite any you find.
 

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -182,10 +182,10 @@ do NOT call /commit-msg first. The PR description file doubles as the commit mes
 
 ```text
 Next: use `/tackle-scratchpad-block` to execute steps one at a time.
-Example: /tackle-scratchpad-block <path-to-scratchpad>
+Example: /tackle-scratchpad-block <absolute-path-to-scratchpad>
 (auto-selects first pending, unblocked step)
 If multiple pending, unblocked steps exist, specify which one:
-  /tackle-scratchpad-block <path-to-scratchpad>#S002
+  /tackle-scratchpad-block <absolute-path-to-scratchpad>#S002
 ```
 
 **IMPORTANT: Do NOT proceed with implementation.**

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -167,7 +167,7 @@ If questions are needed, use `/question` to create a questions file. Add a `**Pl
 
 ## Step 6: Report Status and STOP
 
-Print the branch name, the working-document path, the active-plan pointer path, and any questions file path. Then print a "Next" line that matches the path taken in Step 4:
+Print the branch name, the absolute working-document path, the absolute active-plan pointer path, and any absolute questions file path. Then print a "Next" line that matches the path taken in Step 4:
 
 **Default path (note):**
 

--- a/skills/start-side-quest/SKILL.md
+++ b/skills/start-side-quest/SKILL.md
@@ -121,10 +121,10 @@ Branch: side-quest/<slug>
 Parent: <original branch> (stashed if had changes)
 
 Files created:
-- <base>/notes/<file>.txt (implementation plan, default path)
-  OR <base>/scratchpads/<file>.txt (if --scratchpad)
-- <base>/active-plan-<slug> (pointer to the working document)
-- <base>/questions/<file>.txt (if questions needed)
+- <base>/notes/<file>.txt (implementation plan, absolute path, default)
+  OR <base>/scratchpads/<file>.txt (if --scratchpad, absolute path)
+- <base>/active-plan-<slug> (absolute path, pointer to the working document)
+- <base>/questions/<file>.txt (if questions needed, absolute path)
 
 Stash: <stash message if applicable>
 

--- a/skills/tackle-pr-comment/SKILL.md
+++ b/skills/tackle-pr-comment/SKILL.md
@@ -157,8 +157,8 @@ Only create a questions file for decisions that would fundamentally change the i
 
 Print:
 
-1. The working-document file path (labelled "note" or "scratchpad" to match which path was taken)
-2. The questions file path (if created)
+1. The absolute working-document file path (labelled "note" or "scratchpad" to match which path was taken)
+2. The absolute questions file path (if created)
 3. Brief summary of what you found
 
 **IMPORTANT: Do NOT start implementing changes.**


### PR DESCRIPTION
## Summary

After https://github.com/couimet/my-claude-skills/pull/176 made `.claude-work/` path resolution worktree-aware, the shell scripts correctly produce absolute paths — but every SKILL.md described paths in relative form (`.claude-work/...`). The LLM internalized these examples and sometimes echoed relative paths back to the user, which aren't CMD+CLICKable and fail entirely in worktree setups where `.claude-work/` is at the main checkout root. This PR adds a global rule to `/prose-style` and updates every path-reporting skill to demand absolute paths in terminal output.

## Changes

- `/prose-style` Rule 2 is now scoped to code references in file content, and a new Rule 4 requires absolute paths for any generated file path printed to terminal (notes, scratchpads, questions, commit messages, PR descriptions, breadcrumbs)
- `CLAUDE.md` Working Files section now includes an "Always use absolute paths in terminal output" rule cross-referencing `/prose-style`
- Every skill that reports a generated file path — `/note`, `/scratchpad`, `/question`, `/commit-msg`, `/start-issue`, `/start-side-quest`, `/tackle-pr-comment`, `/finish-issue` — now says "absolute filepath" in its print instructions
- `skills/issue-context/SKILL.md` script contract updated to describe output as absolute rather than relative

## Key Discoveries

- `/breadcrumb` was the only skill that already had this right — its Step 4 explicitly said "full absolute path." Every other path-reporting skill used the bare word "filepath" or showed relative-path examples.
- The active-plan pointer contents (project-root-relative path) is intentionally relative and was left unchanged. It's consumed by skills that resolve it against `<base>`, not by the user.

## Test Plan

- [ ] All existing tests pass (204 tests)
- [ ] Manual testing: run a skill that generates a file and verify the terminal output shows an absolute path that is CMD+CLICKable

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/184

Generated by /finish-issue v2026.07.10@07dd5a8 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Standardized terminal output to report generated file locations using absolute paths.
  - Updated workflow guidance across issue, side-quest, note, scratchpad, question, commit, and PR-related activities.
  - Improved path formatting rules for clearer, directly navigable references.
- **Bug Fixes**
  - Reduced friction when locating generated files by avoiding relative-path ambiguity.
  - Added a micro-release entry documenting the path-reporting fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->