### PR TITLE
[issues/194] Decrease friction: add `Bash(mkdir -p *)` to `allowed-tools` of skills that create `.claude-work/` directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Contributors are encouraged to add a changelog entry with their PR, but it's not
 
 - Relative path friction in skill terminal output. After the worktree-aware `.claude-work/` changes in [issues/173](https://github.com/couimet/my-claude-skills/issues/173), path-producing scripts correctly emit absolute paths but the SKILL.md prose described paths in relative form (`.claude-work/...`), which the LLM sometimes echoed back — producing paths that aren't CMD+CLICKable, especially in worktree setups where `.claude-work/` is at the main checkout root. All path-reporting instructions now require absolute paths, and `/prose-style`'s absolute-paths rule establishes this as a global convention. ([issues/184](https://github.com/couimet/my-claude-skills/issues/184))
 
+## 2026.07.14
+
+### Fixed
+
+- `/start-issue`, `/finish-issue`, `/start-side-quest`, `/tackle-pr-comment`, and `/breadcrumb` now include `Bash(mkdir -p *)` in their `allowed-tools`, eliminating permission prompts that fired whenever `/note` (invoked transitively) or `/breadcrumb` needed to create a `.claude-work/` directory. The transitive coverage rule in CLAUDE.md requires the top-level skill to declare every command its dependencies may call. ([issues/194](https://github.com/couimet/my-claude-skills/issues/194))
+
 ## 2026.07.12
 
 ### Changed

--- a/bats-tests/allowed-tools.bats
+++ b/bats-tests/allowed-tools.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# =============================================================
+# Transitive coverage: skills that invoke /note must declare
+# Bash(mkdir -p *) because /note calls mkdir -p to create the
+# target directory before writing.
+# =============================================================
+
+@test "allowed-tools: start-issue has Bash(mkdir -p *) (invokes /note transitively)" {
+  grep "^allowed-tools:" "$PROJECT_ROOT/skills/start-issue/SKILL.md" | grep -q 'Bash(mkdir -p \*)'
+}
+
+@test "allowed-tools: finish-issue has Bash(mkdir -p *) (invokes /note transitively)" {
+  grep "^allowed-tools:" "$PROJECT_ROOT/skills/finish-issue/SKILL.md" | grep -q 'Bash(mkdir -p \*)'
+}
+
+@test "allowed-tools: start-side-quest has Bash(mkdir -p *) (invokes /note transitively)" {
+  grep "^allowed-tools:" "$PROJECT_ROOT/skills/start-side-quest/SKILL.md" | grep -q 'Bash(mkdir -p \*)'
+}
+
+@test "allowed-tools: tackle-pr-comment has Bash(mkdir -p *) (invokes /note transitively)" {
+  grep "^allowed-tools:" "$PROJECT_ROOT/skills/tackle-pr-comment/SKILL.md" | grep -q 'Bash(mkdir -p \*)'
+}
+
+@test "allowed-tools: breadcrumb has Bash(mkdir -p *) (writes to .claude-work/ directories)" {
+  grep "^allowed-tools:" "$PROJECT_ROOT/skills/breadcrumb/SKILL.md" | grep -q 'Bash(mkdir -p \*)'
+}
+
+@test "allowed-tools: note has Bash(mkdir -p *) (calls mkdir -p directly)" {
+  grep "^allowed-tools:" "$PROJECT_ROOT/skills/note/SKILL.md" | grep -q 'Bash(mkdir -p \*)'
+}
+
+# =============================================================
+# Regression: skills that should NOT have unrestricted Bash
+# =============================================================
+
+@test "allowed-tools: start-issue does not have unrestricted Bash(*)" {
+  ! grep "^allowed-tools:" "$PROJECT_ROOT/skills/start-issue/SKILL.md" | grep -q 'Bash(\*)'
+}
+
+@test "allowed-tools: finish-issue does not have unrestricted Bash(*)" {
+  ! grep "^allowed-tools:" "$PROJECT_ROOT/skills/finish-issue/SKILL.md" | grep -q 'Bash(\*)'
+}
+
+@test "allowed-tools: breadcrumb does not have unrestricted Bash(*)" {
+  ! grep "^allowed-tools:" "$PROJECT_ROOT/skills/breadcrumb/SKILL.md" | grep -q 'Bash(\*)'
+}

--- a/bats-tests/allowed-tools.bats
+++ b/bats-tests/allowed-tools.bats
@@ -47,3 +47,11 @@ load test_helper
 @test "allowed-tools: breadcrumb does not have unrestricted Bash(*)" {
   ! grep "^allowed-tools:" "$PROJECT_ROOT/skills/breadcrumb/SKILL.md" | grep -q 'Bash(\*)'
 }
+
+@test "allowed-tools: start-side-quest does not have unrestricted Bash(*)" {
+  ! grep "^allowed-tools:" "$PROJECT_ROOT/skills/start-side-quest/SKILL.md" | grep -q 'Bash(\*)'
+}
+
+@test "allowed-tools: tackle-pr-comment does not have unrestricted Bash(*)" {
+  ! grep "^allowed-tools:" "$PROJECT_ROOT/skills/tackle-pr-comment/SKILL.md" | grep -q 'Bash(\*)'
+}

--- a/skills/breadcrumb/SKILL.md
+++ b/skills/breadcrumb/SKILL.md
@@ -3,7 +3,7 @@ name: breadcrumb
 version: 2026.07.10@135f415
 description: Drop a timestamped note for the current issue - collected by /finish-issue for PR descriptions
 argument-hint: <note text>
-allowed-tools: Read, Write, Bash(git branch --show-current), Bash(date *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
+allowed-tools: Read, Write, Bash(git branch --show-current), Bash(date *), Bash(mkdir -p *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Breadcrumb

--- a/skills/finish-issue/SKILL.md
+++ b/skills/finish-issue/SKILL.md
@@ -3,7 +3,7 @@ name: finish-issue
 version: 2026.07.10@135f415
 description: Wrap up issue or side-quest work on the current issues/* or side-quest/* branch. Runs verification, checks documentation needs, and generates a PR description
 argument-hint: [optional: issue-number-or-url]
-allowed-tools: Read, Write, Glob, Grep, AskUserQuestion, Bash(git branch --show-current), Bash(git status), Bash(git log *), Bash(git diff *), Bash(make lint-fix *), Bash(make test *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
+allowed-tools: Read, Write, Glob, Grep, AskUserQuestion, Bash(git branch --show-current), Bash(git status), Bash(git log *), Bash(git diff *), Bash(make lint-fix *), Bash(make test *), Bash(mkdir -p *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Finish Issue

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -3,7 +3,7 @@ name: start-issue
 version: 2026.07.10@135f415
 description: Start working on a GitHub issue - analyze, explore codebase, and create detailed implementation plan
 argument-hint: <github-issue-url> [--scratchpad]
-allowed-tools: Read, Write, Glob, Grep, Bash(git branch --show-current), Bash(git fetch *), Bash(git checkout *), Bash(gh issue view *), Bash(gh issue edit * --add-assignee *), Bash(gh api graphql *), Bash(gh issue comment *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *), Bash(*/skills/start-issue/update-project-status.sh *)
+allowed-tools: Read, Write, Glob, Grep, Bash(git branch --show-current), Bash(git fetch *), Bash(git checkout *), Bash(gh issue view *), Bash(gh issue edit * --add-assignee *), Bash(gh api graphql *), Bash(gh issue comment *), Bash(mkdir -p *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *), Bash(*/skills/start-issue/update-project-status.sh *)
 ---
 
 # Start Issue

--- a/skills/start-side-quest/SKILL.md
+++ b/skills/start-side-quest/SKILL.md
@@ -3,7 +3,7 @@ name: start-side-quest
 version: 2026.07.10@135f415
 description: Start a side-quest branch for orthogonal improvements discovered while working on an issue
 argument-hint: <description | path/to/file.ts#L10-L20> [--scratchpad]
-allowed-tools: Read, Write, Glob, Grep, Bash(git fetch *), Bash(git checkout *), Bash(git branch --show-current), Bash(git status *), Bash(git stash *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
+allowed-tools: Read, Write, Glob, Grep, Bash(git fetch *), Bash(git checkout *), Bash(git branch --show-current), Bash(git status *), Bash(git stash *), Bash(mkdir -p *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Start Side-Quest

--- a/skills/tackle-pr-comment/SKILL.md
+++ b/skills/tackle-pr-comment/SKILL.md
@@ -3,7 +3,7 @@ name: tackle-pr-comment
 version: 2026.07.10@135f415
 description: Tackle a PR comment - analyze feedback, explore code, and create implementation working document
 argument-hint: <pr-comment-url> [--scratchpad]
-allowed-tools: Read, Glob, Grep, Write, Bash(gh api repos/*/*/pulls/*/reviews/*), Bash(gh api repos/*/*/pulls/comments/*), Bash(gh api repos/*/*/issues/comments/*), Bash(gh api repos/*/*/pulls/*/comments*), Bash(gh api repos/*/*/issues/*/comments*), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
+allowed-tools: Read, Glob, Grep, Write, Bash(gh api repos/*/*/pulls/*/reviews/*), Bash(gh api repos/*/*/pulls/comments/*), Bash(gh api repos/*/*/issues/comments/*), Bash(gh api repos/*/*/pulls/*/comments*), Bash(gh api repos/*/*/issues/*/comments*), Bash(mkdir -p *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Tackle PR Comment


### PR DESCRIPTION
## Summary

Skills that invoke `/note` transitively (`/start-issue`, `/finish-issue`, `/start-side-quest`, `/tackle-pr-comment`) triggered a permission prompt every time `/note` called `mkdir -p` to create a `.claude-work/` directory. Because `allowed-tools` is checked against the top-level skill, not the foundation skill, `/note`'s own `Bash(mkdir -p *)` permission didn't apply transitively. This fix adds the permission to all five affected skills and enforces the pattern with new tests.

## Changes

- Four top-level skills now declare `Bash(mkdir -p *)` in their `allowed-tools`, covering the transitive `/note` → `mkdir -p` call chain via `skills/start-issue/SKILL.md`, `skills/finish-issue/SKILL.md`, `skills/start-side-quest/SKILL.md`, and `skills/tackle-pr-comment/SKILL.md`
- `/breadcrumb` also gets `Bash(mkdir -p *)` since it writes directly to `.claude-work/` directories that may not exist at write time via `skills/breadcrumb/SKILL.md`
- New `bats-tests/allowed-tools.bats` with 9 tests: 6 positive tests verifying each skill has `Bash(mkdir -p *)`, 3 regression tests verifying no skill accidentally got unrestricted `Bash(*)`

## Key Discoveries

- `/question`, `/scratchpad`, and `/commit-msg` were correctly excluded: they use `target-path.sh` which creates directories inside the shell script, so the transitive coverage rule doesn't apply to `mkdir` for those skills
- The permission model cascades down, not up: foundation skills declare what they need for direct invocation; top-level skills must redundantly declare everything their transitive dependencies may call

## Test Plan

- [x] All 213 existing tests pass
- [x] 9 new allowed-tools tests added and passing
- [ ] Manual testing: run `/start-issue` on a fresh issue to confirm no `mkdir` permission prompt fires

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/194

Generated by /finish-issue v2026.07.10@135f415 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue and side-quest workflows to prevent unnecessary permission prompts when creating working directories.
  * Improved workflow access for project status updates and issue-context operations.

* **Tests**
  * Added regression checks to verify required permissions remain available while unrestricted shell access is not enabled.

* **Documentation**
  * Added release notes describing these workflow reliability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->