### PR TITLE
[issues/192] Fix plural typo in skill-hooks convention line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ Contributors are encouraged to add a changelog entry with their PR, but it's not
 
 - `/start-issue`, `/finish-issue`, `/start-side-quest`, `/tackle-pr-comment`, and `/breadcrumb` now include `Bash(mkdir -p *)` in their `allowed-tools`, eliminating permission prompts that fired whenever `/note` (invoked transitively) or `/breadcrumb` needed to create a `.claude-work/` directory. The transitive coverage rule in CLAUDE.md requires the top-level skill to declare every command its dependencies may call. ([issues/194](https://github.com/couimet/my-claude-skills/issues/194))
 
+## 2026.07.14.1
+
+### Fixed
+
+- Fixed a one-word plural typo in `/skill-hooks`: the convention line said `{parent-skill}-hooks` (plural) while the rest of the repo consistently uses `-hook` (singular). This was the last remaining inconsistency from the June 17 rename. ([issues/192](https://github.com/couimet/my-claude-skills/issues/192))
+
 ## 2026.07.12
 
 ### Changed

--- a/skills/skill-hooks/SKILL.md
+++ b/skills/skill-hooks/SKILL.md
@@ -16,7 +16,7 @@ Some skills in this collection (like `/start-issue`, `/finish-issue`, and `/star
 
 ## Convention
 
-A project creates a foundation skill in `.claude/skills/` with the name `{parent-skill}-hooks`:
+A project creates a foundation skill in `.claude/skills/` with the name `{parent-skill}-hook`:
 
 | Parent skill | Hook skill name | What it can add |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

Fixed a one-word plural typo in the `/skill-hooks` foundation skill: the convention line said `{parent-skill}-hooks` (plural) while the rest of the repo consistently uses `-hook` (singular). This was the last remaining inconsistency from the June 17 rename.

## Changes

- `/skill-hooks` convention line corrected from `{parent-skill}-hooks` to `{parent-skill}-hook`, matching the table below it, the RangeLink example, all three parent skills, the ADR, and the README
- Documentation: CHANGELOG [fixed]

## Test Plan

- [x] All existing tests pass (215/215)
- [ ] Manual testing: not applicable — prose-only change

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/192

Generated by /finish-issue v2026.07.10@13a80e2 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@coderabbitai ignore