### PR TITLE
[issues/190] Add Dependabot config for GitHub Actions weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'America/Toronto'
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable automated weekly GitHub Actions dependency updates. This repo is Shell-based with no npm dependencies, so only the `github-actions` ecosystem is configured. Follows the pattern established by https://github.com/couimet/ts-npm-packages/pull/95 as part of the account-wide Dependabot rollout.

## Changes

- Dependabot enabled for GitHub Actions with weekly Monday 9am Toronto schedule and a single grouped PR for all action version bumps

## Test Plan

- [x] All existing tests pass (215/215)
- [ ] New tests added for: none (config file only)
- [ ] Manual testing: YAML syntax confirmed valid via `python3 -c "import yaml; yaml.safe_load(...)"`. Dependabot validates the config on merge.

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/190

Generated by /finish-issue v2026.07.10@941dbb2 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@coderabbitai ignore