### PR TITLE
[issues/182] Cross-repo issue dependency linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.07.14.3
+
+### Added
+
+- `/add-github-dependency` skill: add `blocked-by` or `is-blocking` dependency relationships between GitHub issues using the native `addBlockedBy` mutation. Works cross-repo — node IDs are globally unique, so same-repo and cross-repo linking use the same code path. Accepts a relationship type and target URL as arguments (e.g., `/add-github-dependency blocked-by https://github.com/other/repo/issues/42`). ([issues/182](https://github.com/couimet/my-claude-skills/issues/182))
+
+### Changed
+
+- `/create-github-issue` now infers dependency relationships from natural language in issue drafts — "depends on", "blocked by", "waiting on", "this blocks", "unblocks", etc. — and creates native dependency links via `addBlockedBy` at issue creation time. No required phrasing. Cross-references `/add-github-dependency` for post-creation workflows. Backed by a unified `link-dependency.sh` script shared by both skills. ([issues/182](https://github.com/couimet/my-claude-skills/issues/182))
+
 ## 2026.07.14.2
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ I've used Claude Code on dozens of real issues and kept running into the same fr
 
 | Command | What It Does |
 | --- | --- |
+| `/add-github-dependency <blocked-by\|is-blocking> <issue-url>` | Add a dependency relationship between two GitHub issues using the native `addBlockedBy` mutation — works cross-repo |
 | `/breadcrumb <note>` | Drop a timestamped note collected by `/finish-issue` for the PR description |
 | `/changelog <desc>` | Create or update a CHANGELOG entry with tone guardrails, thematic grouping, and detail-leak detection — adapts to SemVer, CalVer, and mono-repo layouts |
 | `/cleanup-issue [number]` | Delete an issue's working directory (`.claude-work/issues/<ID>/`) after confirming with the user |

--- a/bats-tests/link-dependency.bats
+++ b/bats-tests/link-dependency.bats
@@ -1,0 +1,320 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+SCRIPT="$PROJECT_ROOT/skills/create-github-issue/link-dependency.sh"
+
+# --- Mock gh for runtime error code tests ---
+
+setup() {
+  MOCK_DIR="$(mktemp -d)"
+  export MOCK_DIR
+
+  export GH_COUNTER="$MOCK_DIR/gh-counter"
+  echo "0" > "$GH_COUNTER"
+
+  cat > "$MOCK_DIR/gh" <<'MOCK_SCRIPT'
+#!/usr/bin/env bash
+case "$1" in
+  api)
+    COUNTER=$(cat "$GH_COUNTER")
+    COUNTER=$((COUNTER + 1))
+    echo "$COUNTER" > "$GH_COUNTER"
+
+    case "$COUNTER" in
+      1)  # Subject query
+        if [ "${GH_FAIL_SUBJECT_QUERY:-}" = "true" ]; then
+          echo "mock: subject query failed" >&2
+          exit 1
+        fi
+        if [ "${GH_EMPTY_SUBJECT_ID:-}" = "true" ]; then
+          echo '{"data":{"repository":{"issue":null}}}'
+        else
+          echo '{"data":{"repository":{"issue":{"id":"SUBJECT_NODE_ID"}}}}'
+        fi
+        ;;
+      2)  # Target query
+        if [ "${GH_FAIL_TARGET_QUERY:-}" = "true" ]; then
+          echo "mock: target query failed" >&2
+          exit 1
+        fi
+        if [ "${GH_EMPTY_TARGET_ID:-}" = "true" ]; then
+          echo '{"data":{"repository":{"issue":null}}}'
+        else
+          echo '{"data":{"repository":{"issue":{"id":"TARGET_NODE_ID"}}}}'
+        fi
+        ;;
+      3)  # Mutation
+        if [ "${GH_FAIL_MUTATION:-}" = "true" ]; then
+          echo "mock: mutation failed" >&2
+          exit 1
+        fi
+        if [ "${GH_GRAPHQL_ERRORS:-}" = "true" ]; then
+          echo '{"errors":[{"message":"Dependency already exists"}]}'
+        else
+          echo '{"data":{"addBlockedBy":{"issue":{"number":10},"blockingIssue":{"number":5}}}}'
+        fi
+        ;;
+    esac
+    ;;
+esac
+MOCK_SCRIPT
+  chmod +x "$MOCK_DIR/gh"
+
+  export ORIG_PATH="$PATH"
+  export PATH="$MOCK_DIR:$PATH"
+}
+
+teardown() {
+  rm -rf "$MOCK_DIR"
+}
+
+# --- Missing parameters ---
+
+@test "missing all parameters prints error with E001" {
+  run "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E001"* ]]
+  [[ "$output" == *"--subject-owner"* ]]
+  [[ "$output" == *"--subject-repo"* ]]
+  [[ "$output" == *"--subject-number"* ]]
+  [[ "$output" == *"--target-owner"* ]]
+  [[ "$output" == *"--target-repo"* ]]
+  [[ "$output" == *"--target-number"* ]]
+  [[ "$output" == *"--relationship"* ]]
+}
+
+@test "missing --relationship parameter prints error with E001" {
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo --target-number 5
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E001"* ]]
+  [[ "$output" == *"--relationship"* ]]
+}
+
+@test "missing --subject-number parameter prints error with E001" {
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo \
+                --target-owner other --target-repo other-repo --target-number 5 \
+                --relationship blocked-by
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E001"* ]]
+  [[ "$output" == *"--subject-number"* ]]
+}
+
+@test "missing --target-number parameter prints error with E001" {
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo \
+                --relationship is-blocking
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E001"* ]]
+  [[ "$output" == *"--target-number"* ]]
+}
+
+# --- Invalid numbers ---
+
+@test "non-numeric --subject-number prints error with E102" {
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number abc \
+                --target-owner other --target-repo other-repo --target-number 5 \
+                --relationship blocked-by
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E102"* ]]
+  [[ "$output" == *"--subject-number"* ]]
+}
+
+@test "non-numeric --target-number prints error with E105" {
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo --target-number xyz \
+                --relationship blocked-by
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E105"* ]]
+  [[ "$output" == *"--target-number"* ]]
+}
+
+# --- Invalid relationship ---
+
+@test "invalid relationship type prints error with E106" {
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo --target-number 5 \
+                --relationship depends-on
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E106"* ]]
+  [[ "$output" == *"--relationship"* ]]
+  [[ "$output" == *"depends-on"* ]]
+}
+
+@test "empty relationship value treated as missing (E001)" {
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo --target-number 5 \
+                --relationship ""
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E001"* ]]
+  [[ "$output" == *"--relationship"* ]]
+}
+
+# --- Unknown parameters ---
+
+@test "unknown parameter prints error with E002" {
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo --target-number 5 \
+                --relationship blocked-by --verbose
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E002"* ]]
+  [[ "$output" == *"--verbose"* ]]
+}
+
+@test "positional parameter prints error with E002" {
+  run "$SCRIPT" couimet
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E002"* ]]
+}
+
+# --- Parameter value missing ---
+
+@test "--subject-owner without value prints error with E100" {
+  run "$SCRIPT" --subject-owner
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E100"* ]]
+  [[ "$output" == *"--subject-owner"* ]]
+}
+
+@test "--subject-repo without value prints error with E101" {
+  run "$SCRIPT" --subject-owner couimet --subject-repo
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E101"* ]]
+  [[ "$output" == *"--subject-repo"* ]]
+}
+
+@test "--target-owner without value prints error with E103" {
+  run "$SCRIPT" --subject-owner couimet --target-owner
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E103"* ]]
+  [[ "$output" == *"--target-owner"* ]]
+}
+
+@test "--target-repo without value prints error with E104" {
+  run "$SCRIPT" --subject-owner couimet --target-owner other --target-repo
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E104"* ]]
+  [[ "$output" == *"--target-repo"* ]]
+}
+
+@test "--relationship without value prints error with E106" {
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo --target-number 5 \
+                --relationship
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E106"* ]]
+  [[ "$output" == *"--relationship"* ]]
+}
+
+# --- Self-dependency ---
+
+@test "same subject and target prints error with E107" {
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner couimet --target-repo my-repo --target-number 10 \
+                --relationship blocked-by
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E107"* ]]
+  [[ "$output" == *"same issue"* ]]
+}
+
+# --- Runtime: subject node lookup failure (E200) ---
+
+@test "subject node lookup failure prints error with E200" {
+  export GH_FAIL_SUBJECT_QUERY=true
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo --target-number 5 \
+                --relationship blocked-by
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E200"* ]]
+  [[ "$output" == *"subject node ID lookup failed"* ]]
+}
+
+# --- Runtime: target node lookup failure (E201) ---
+
+@test "target node lookup failure prints error with E201" {
+  export GH_FAIL_TARGET_QUERY=true
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo --target-number 5 \
+                --relationship blocked-by
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E201"* ]]
+  [[ "$output" == *"target node ID lookup failed"* ]]
+}
+
+# --- Runtime: empty subject node ID (E202) ---
+
+@test "empty subject node ID prints error with E202" {
+  export GH_EMPTY_SUBJECT_ID=true
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo --target-number 5 \
+                --relationship blocked-by
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E202"* ]]
+  [[ "$output" == *"could not resolve node ID for subject issue"* ]]
+}
+
+# --- Runtime: empty target node ID (E203) ---
+
+@test "empty target node ID prints error with E203" {
+  export GH_EMPTY_TARGET_ID=true
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo --target-number 5 \
+                --relationship blocked-by
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E203"* ]]
+  [[ "$output" == *"could not resolve node ID for target issue"* ]]
+}
+
+# --- Runtime: mutation failure (E204) ---
+
+@test "mutation failure (gh exit) prints error with E204" {
+  export GH_FAIL_MUTATION=true
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo --target-number 5 \
+                --relationship blocked-by
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E204"* ]]
+  [[ "$output" == *"addBlockedBy mutation failed"* ]]
+}
+
+@test "mutation GraphQL errors prints error with E204" {
+  export GH_GRAPHQL_ERRORS=true
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo --target-number 5 \
+                --relationship blocked-by
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E204"* ]]
+  [[ "$output" == *"Dependency already exists"* ]]
+}
+
+# --- Success: blocked-by (same repo) ---
+
+@test "blocked-by same-repo prints expected output" {
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner couimet --target-repo my-repo --target-number 5 \
+                --relationship blocked-by
+  [ "$status" -eq 0 ]
+  [[ "$output" == "blocked #10 ← #5" ]]
+}
+
+# --- Success: is-blocking (cross-repo) ---
+
+@test "is-blocking cross-repo prints expected output" {
+  run "$SCRIPT" --subject-owner couimet --subject-repo my-repo --subject-number 10 \
+                --target-owner other --target-repo other-repo --target-number 5 \
+                --relationship is-blocking
+  [ "$status" -eq 0 ]
+  [[ "$output" == "blocking #10 → #5" ]]
+}
+
+# --- Help ---
+
+@test "--help prints usage and exits 0" {
+  run "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"--subject-owner"* ]]
+  [[ "$output" == *"--target-owner"* ]]
+  [[ "$output" == *"--relationship"* ]]
+}

--- a/skills/add-github-dependency/SKILL.md
+++ b/skills/add-github-dependency/SKILL.md
@@ -4,7 +4,7 @@ version: 2026.07.14@local
 description: Add a dependency relationship between GitHub issues using the native addBlockedBy mutation
 argument-hint: <blocked-by|is-blocking> <issue-url>
 user-invocable: true
-allowed-tools: Read, Bash(*/skills/create-github-issue/link-dependency.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
+allowed-tools: Read, Bash(*/skills/create-github-issue/link-dependency.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *), Bash(gh repo view *)
 ---
 
 # Add GitHub Dependency

--- a/skills/add-github-dependency/SKILL.md
+++ b/skills/add-github-dependency/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: add-github-dependency
+version: 2026.07.14@local
+description: Add a dependency relationship between GitHub issues using the native addBlockedBy mutation
+argument-hint: <blocked-by|is-blocking> <issue-url>
+user-invocable: true
+allowed-tools: Read, Bash(*/skills/create-github-issue/link-dependency.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
+---
+
+# Add GitHub Dependency
+
+Add a dependency relationship between GitHub issues using GitHub's native `addBlockedBy` mutation. Works cross-repo — node IDs are globally unique, so the mutation handles same-repo and cross-repo identically.
+
+**Input:** `$ARGUMENTS` — a relationship type (`blocked-by` or `is-blocking`) followed by a target issue URL.
+
+## Step 1: Parse Arguments
+
+Split `$ARGUMENTS` on whitespace. The first token is the relationship type; the second is the target issue URL.
+
+Validate the relationship type:
+
+```text
+blocked-by   — the current issue IS BLOCKED BY the target issue
+is-blocking  — the current issue IS BLOCKING the target issue
+```
+
+If the relationship type is not one of these two values, print an error and exit:
+
+```text
+add-github-dependency: invalid relationship type '<type>'. Expected 'blocked-by' or 'is-blocking'.
+Usage: /add-github-dependency <blocked-by|is-blocking> <issue-url>
+```
+
+Parse the target URL to extract owner, repo, and issue number. The URL format is:
+
+```text
+https://github.com/<owner>/<repo>/issues/<number>
+```
+
+If the URL does not match this pattern, print an error and exit:
+
+```text
+add-github-dependency: could not parse issue URL '<url>'. Expected format: https://github.com/<owner>/<repo>/issues/<number>
+```
+
+## Step 2: Resolve Subject Issue
+
+Resolve the current branch's issue number as the subject via `target-path.sh`:
+
+```bash
+~/.claude/skills/issue-context/target-path.sh
+```
+
+Parse the subject issue number from the branch name (e.g., `issues/182` → `182`). If the current branch is not an `issues/*` branch, print an error and exit:
+
+```text
+add-github-dependency: current branch is not an issues/* branch. Switch to the issue branch for the subject issue first.
+```
+
+Determine the subject's owner and repo from the current git remote:
+
+```bash
+gh repo view --json owner,name
+```
+
+If this fails, print an error and exit:
+
+```text
+add-github-dependency: could not determine current repository. Run from within a git repository.
+```
+
+## Step 3: Link the Dependency
+
+Call the unified linking script:
+
+```bash
+~/.claude/skills/create-github-issue/link-dependency.sh \
+  --subject-owner "$SUBJECT_OWNER" \
+  --subject-repo "$SUBJECT_REPO" \
+  --subject-number "$SUBJECT_NUMBER" \
+  --target-owner "$TARGET_OWNER" \
+  --target-repo "$TARGET_REPO" \
+  --target-number "$TARGET_NUMBER" \
+  --relationship "$RELATIONSHIP"
+```
+
+Report the result:
+
+**On success:** print the script's output line.
+
+**On failure:** print the error and exit with:
+
+```text
+add-github-dependency: linking failed — <error message>
+```
+
+Formatting: see `/prose-style` for hard-wrap, code-reference, and GitHub-reference rules.

--- a/skills/create-github-issue/SKILL.md
+++ b/skills/create-github-issue/SKILL.md
@@ -3,7 +3,7 @@ name: create-github-issue
 version: 2026.07.14.2@af93660
 description: Create a GitHub issue from a file draft or inline description, with smart label discovery and sub-issue linking
 argument-hint: <file-path-or-title>
-allowed-tools: Read, Write, Glob, Bash(gh repo view *), Bash(gh label list *), Bash(gh issue create *), Bash(*/skills/create-github-issue/link-sub-issue.sh *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
+allowed-tools: Read, Write, Glob, Bash(gh repo view *), Bash(gh label list *), Bash(gh issue create *), Bash(*/skills/create-github-issue/link-sub-issue.sh *), Bash(*/skills/create-github-issue/link-dependency.sh *), Bash(*/skills/auto-number/auto-number.sh *), Bash(*/skills/ensure-gitignore/ensure-gitignore.sh *), Bash(*/skills/issue-context/target-path.sh *), Bash(*/skills/issue-context/claude-work-root.sh *)
 ---
 
 # Create GitHub Issue
@@ -29,6 +29,8 @@ Read the file and extract:
 - **Body**: everything after the title heading
 
 If the file contains a `## Parent` or `Parent: #NN` line, extract the parent issue number for sub-issue linking in Step 6.
+
+Scan the body for dependency relationships to other GitHub issues. The user may express these in natural language — "depends on X", "needs X first", "waiting on X", "blocked by X", "this blocks Y", "unblocks Z", etc. — not with any required phrasing. For each relationship you detect, determine the direction (blocked-by or is-blocking) and extract the full GitHub issue URL. These can reference issues in any repository, including the current one. There can be zero, one, or multiple such relationships.
 
 If the file contains a `**Target repo:** owner/repo` line (e.g., `**Target repo:** couimet/my-claude-skills`), extract it as the target repository override. When no target repo line is present, infer owner/repo from the current git remote (`gh repo view --json owner,name`).
 
@@ -94,7 +96,7 @@ Run the script once per child issue to link:
 
 The script handles all GraphQL calls internally, using `jq -n` to build payloads via temp files to avoid zsh history expansion stripping `!` from GraphQL type annotations (`String!`, `Int!`, `ID!`). It prints `linked #<child> → #<parent>` on success or an error message on failure (exit 1).
 
-If the script fails, note it in the Step 7 report as:
+If the script fails, note it in the Step 8 report as:
 
 ```text
 Sub-issue linking: failed (<error summary>). Link manually if needed.
@@ -102,7 +104,38 @@ Sub-issue linking: failed (<error summary>). Link manually if needed.
 
 If no parent was specified, skip this step.
 
-## Step 7: Report
+## Step 7: Link Dependencies (If Blocked By / Is Blocking Specified)
+
+If `Blocked by` or `Is blocking` URLs were extracted in Step 2, link each dependency using the `link-dependency.sh` script.
+
+Parse `OWNER`, `REPO`, and `SUBJECT_NUMBER` from the issue URL returned in Step 5 (`https://github.com/{OWNER}/{REPO}/issues/{SUBJECT_NUMBER}`). If a target repo override was extracted in Step 2, use that owner/repo instead.
+
+For each dependency URL detected in Step 2, parse `TARGET_OWNER`, `TARGET_REPO`, and `TARGET_NUMBER` from the URL, then run:
+
+```bash
+~/.claude/skills/create-github-issue/link-dependency.sh \
+  --subject-owner "$OWNER" \
+  --subject-repo "$REPO" \
+  --subject-number "$SUBJECT_NUMBER" \
+  --target-owner "$TARGET_OWNER" \
+  --target-repo "$TARGET_REPO" \
+  --target-number "$TARGET_NUMBER" \
+  --relationship "$RELATIONSHIP"
+```
+
+Where `$RELATIONSHIP` is `blocked-by` (when this issue depends on the other) or `is-blocking` (when this issue unblocks the other), as inferred from the natural language in the body. The script handles all GraphQL calls internally, using `jq -n` to build payloads via temp files to avoid zsh history expansion stripping `!` from GraphQL type annotations (`String!`, `Int!`, `ID!`). It maps the relationship to `addBlockedBy` argument order and prints `blocked #<subject> ← #<target>` or `blocking #<subject> → #<target>` on success.
+
+If the script fails, note it in the Step 8 report as:
+
+```text
+Dependency linking: failed for <URL> (<error summary>). Link manually if needed.
+```
+
+To add dependencies to an existing issue (rather than at creation time), use `/add-github-dependency <blocked-by|is-blocking> <issue-url>`.
+
+If no dependency URLs were extracted, skip this step.
+
+## Step 8: Report
 
 Print a summary:
 
@@ -112,6 +145,9 @@ Title: <TITLE>
 Labels: <LABEL1>, <LABEL2>
 Parent: https://github.com/{OWNER}/{REPO}/issues/{PARENT_NUMBER} (linked as sub-issue)  ← only if parent specified AND linking succeeded
 Sub-issue linking: failed (<error summary>). Link manually if needed.  ← only if parent specified AND linking failed
+Blocked by: <URL> (linked)  ← one per successful blocked-by dependency
+Is blocking: <URL> (linked)  ← one per successful is-blocking dependency
+Dependency linking: failed for <URL> (<error summary>). Link manually if needed.  ← one per failed dependency
 ```
 
 Formatting: see `/prose-style` for hard-wrap, code-reference, and GitHub-reference rules.

--- a/skills/create-github-issue/link-dependency.sh
+++ b/skills/create-github-issue/link-dependency.sh
@@ -166,9 +166,9 @@ if [ "$subject_owner" = "$target_owner" ] && [ "$subject_repo" = "$target_repo" 
 fi
 
 # --- Temp files for GraphQL payloads ---
-subject_payload="$(mktemp "${TMPDIR:-/tmp}/link-dependency.subject.XXXXXX.json")"
-target_payload="$(mktemp "${TMPDIR:-/tmp}/link-dependency.target.XXXXXX.json")"
-mutation_payload="$(mktemp "${TMPDIR:-/tmp}/link-dependency.mutation.XXXXXX.json")"
+subject_payload="$(mktemp "${TMPDIR:-/tmp}/link-dependency.subject.XXXXXX")"
+target_payload="$(mktemp "${TMPDIR:-/tmp}/link-dependency.target.XXXXXX")"
+mutation_payload="$(mktemp "${TMPDIR:-/tmp}/link-dependency.mutation.XXXXXX")"
 trap 'rm -f "$subject_payload" "$target_payload" "$mutation_payload"' EXIT
 
 # --- Step 1: Fetch subject node ID ---

--- a/skills/create-github-issue/link-dependency.sh
+++ b/skills/create-github-issue/link-dependency.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+#
+# link-dependency.sh — Link a GitHub issue dependency using addBlockedBy mutation.
+#
+# Usage: link-dependency.sh --subject-owner OWNER --subject-repo REPO --subject-number NUMBER \
+#                           --target-owner OWNER --target-repo REPO --target-number NUMBER \
+#                           --relationship blocked-by|is-blocking
+#
+#   --subject-owner   Owner of the subject issue (the issue being created or on the current branch)
+#   --subject-repo    Repository of the subject issue
+#   --subject-number  Subject issue number
+#   --target-owner    Owner of the target issue (the dependency)
+#   --target-repo     Repository of the target issue
+#   --target-number   Target issue number
+#   --relationship    "blocked-by" (subject is blocked by target) or
+#                     "is-blocking" (subject is blocking target)
+#
+# Uses addBlockedBy mutation with globally-unique node IDs, so cross-repo linking
+# works the same as same-repo. Uses jq -n to build GraphQL payloads via temp files,
+# avoiding zsh history expansion that silently strips ! from type annotations.
+#
+# Output: "blocked #<subject> ← #<target>" or "blocking #<subject> → #<target>" on success.
+# Error messages on failure (exit 1).
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: link-dependency.sh --subject-owner OWNER --subject-repo REPO --subject-number NUMBER \
+                          --target-owner OWNER --target-repo REPO --target-number NUMBER \
+                          --relationship blocked-by|is-blocking
+
+  --subject-owner   Owner of the subject issue
+  --subject-repo    Repository of the subject issue
+  --subject-number  Subject issue number
+  --target-owner    Owner of the target issue (the dependency)
+  --target-repo     Repository of the target issue
+  --target-number   Target issue number
+  --relationship    "blocked-by" (subject is blocked by target) or
+                    "is-blocking" (subject is blocking target)
+  --help            Show this help message
+EOF
+}
+
+# --- Error codes (all exit 1) ---
+# E0xx: generic errors
+readonly ERR_MISSING_PARAM="E001"
+readonly ERR_UNKNOWN_PARAM="E002"
+# E1xx: parameter validation (per-flag)
+readonly ERR_INVALID_SUBJECT_OWNER="E100"
+readonly ERR_INVALID_SUBJECT_REPO="E101"
+readonly ERR_INVALID_SUBJECT_NUMBER="E102"
+readonly ERR_INVALID_TARGET_OWNER="E103"
+readonly ERR_INVALID_TARGET_REPO="E104"
+readonly ERR_INVALID_TARGET_NUMBER="E105"
+readonly ERR_INVALID_RELATIONSHIP="E106"
+readonly ERR_SAME_ISSUE="E107"
+# E2xx: runtime errors
+readonly ERR_SUBJECT_NODE_LOOKUP="E200"
+readonly ERR_TARGET_NODE_LOOKUP="E201"
+readonly ERR_EMPTY_SUBJECT_NODE_ID="E202"
+readonly ERR_EMPTY_TARGET_NODE_ID="E203"
+readonly ERR_MUTATION="E204"
+
+# --- Defaults ---
+subject_owner=""
+subject_repo=""
+subject_number=""
+target_owner=""
+target_repo=""
+target_number=""
+relationship=""
+
+# --- Parse arguments ---
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --subject-owner)
+      [ $# -ge 2 ] || { echo "link-dependency $ERR_INVALID_SUBJECT_OWNER error: --subject-owner requires a value" >&2; exit 1; }
+      subject_owner="$2"
+      shift 2
+      ;;
+    --subject-repo)
+      [ $# -ge 2 ] || { echo "link-dependency $ERR_INVALID_SUBJECT_REPO error: --subject-repo requires a value" >&2; exit 1; }
+      subject_repo="$2"
+      shift 2
+      ;;
+    --subject-number)
+      [ $# -ge 2 ] || { echo "link-dependency $ERR_INVALID_SUBJECT_NUMBER error: --subject-number requires a value" >&2; exit 1; }
+      subject_number="$2"
+      shift 2
+      ;;
+    --target-owner)
+      [ $# -ge 2 ] || { echo "link-dependency $ERR_INVALID_TARGET_OWNER error: --target-owner requires a value" >&2; exit 1; }
+      target_owner="$2"
+      shift 2
+      ;;
+    --target-repo)
+      [ $# -ge 2 ] || { echo "link-dependency $ERR_INVALID_TARGET_REPO error: --target-repo requires a value" >&2; exit 1; }
+      target_repo="$2"
+      shift 2
+      ;;
+    --target-number)
+      [ $# -ge 2 ] || { echo "link-dependency $ERR_INVALID_TARGET_NUMBER error: --target-number requires a value" >&2; exit 1; }
+      target_number="$2"
+      shift 2
+      ;;
+    --relationship)
+      [ $# -ge 2 ] || { echo "link-dependency $ERR_INVALID_RELATIONSHIP error: --relationship requires a value" >&2; exit 1; }
+      relationship="$2"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "link-dependency $ERR_UNKNOWN_PARAM error: unknown parameter '$1'" >&2
+      exit 1
+      ;;
+    *)
+      echo "link-dependency $ERR_UNKNOWN_PARAM error: unexpected parameter '$1'" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# --- Validate required flags ---
+missing=()
+[ -n "$subject_owner" ]  || missing+=("--subject-owner")
+[ -n "$subject_repo" ]   || missing+=("--subject-repo")
+[ -n "$subject_number" ] || missing+=("--subject-number")
+[ -n "$target_owner" ]   || missing+=("--target-owner")
+[ -n "$target_repo" ]    || missing+=("--target-repo")
+[ -n "$target_number" ]  || missing+=("--target-number")
+[ -n "$relationship" ]   || missing+=("--relationship")
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "link-dependency $ERR_MISSING_PARAM error: missing required parameter(s): ${missing[*]}" >&2
+  exit 1
+fi
+
+# --- Validate numbers ---
+if ! [[ "$subject_number" =~ ^[0-9]+$ ]]; then
+  echo "link-dependency $ERR_INVALID_SUBJECT_NUMBER error: --subject-number must be a positive integer (got '$subject_number')" >&2
+  exit 1
+fi
+
+if ! [[ "$target_number" =~ ^[0-9]+$ ]]; then
+  echo "link-dependency $ERR_INVALID_TARGET_NUMBER error: --target-number must be a positive integer (got '$target_number')" >&2
+  exit 1
+fi
+
+# --- Validate relationship ---
+case "$relationship" in
+  blocked-by|is-blocking) ;;
+  *)
+    echo "link-dependency $ERR_INVALID_RELATIONSHIP error: --relationship must be 'blocked-by' or 'is-blocking' (got '$relationship')" >&2
+    exit 1
+    ;;
+esac
+
+# --- Validate not the same issue ---
+if [ "$subject_owner" = "$target_owner" ] && [ "$subject_repo" = "$target_repo" ] && [ "$subject_number" = "$target_number" ]; then
+  echo "link-dependency $ERR_SAME_ISSUE error: subject and target are the same issue (#$subject_number). An issue cannot depend on itself." >&2
+  exit 1
+fi
+
+# --- Temp files for GraphQL payloads ---
+subject_payload="$(mktemp "${TMPDIR:-/tmp}/link-dependency.subject.XXXXXX.json")"
+target_payload="$(mktemp "${TMPDIR:-/tmp}/link-dependency.target.XXXXXX.json")"
+mutation_payload="$(mktemp "${TMPDIR:-/tmp}/link-dependency.mutation.XXXXXX.json")"
+trap 'rm -f "$subject_payload" "$target_payload" "$mutation_payload"' EXIT
+
+# --- Step 1: Fetch subject node ID ---
+jq -n \
+  --arg owner "$subject_owner" \
+  --arg repo "$subject_repo" \
+  --argjson number "$subject_number" \
+  '{"query": "query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: $repo) { issue(number: $number) { id } } }", "variables": {"owner": $owner, "repo": $repo, "number": $number}}' \
+  > "$subject_payload"
+
+SUBJECT_RESULT=$(gh api graphql --input "$subject_payload" 2>&1) || {
+  echo "link-dependency $ERR_SUBJECT_NODE_LOOKUP error: subject node ID lookup failed — $SUBJECT_RESULT" >&2
+  exit 1
+}
+
+SUBJECT_NODE_ID=$(echo "$SUBJECT_RESULT" | jq -r '.data.repository.issue.id // empty')
+
+if [ -z "$SUBJECT_NODE_ID" ]; then
+  echo "link-dependency $ERR_EMPTY_SUBJECT_NODE_ID error: could not resolve node ID for subject issue #$subject_number in $subject_owner/$subject_repo" >&2
+  exit 1
+fi
+
+# --- Step 2: Fetch target node ID ---
+# When subject and target are in the same repo, we could reuse the first query.
+# For simplicity (and because addBlockedBy needs both IDs anyway), always query
+# separately. This handles cross-repo without special-casing.
+
+jq -n \
+  --arg owner "$target_owner" \
+  --arg repo "$target_repo" \
+  --argjson number "$target_number" \
+  '{"query": "query($owner: String!, $repo: String!, $number: Int!) { repository(owner: $owner, name: $repo) { issue(number: $number) { id } } }", "variables": {"owner": $owner, "repo": $repo, "number": $number}}' \
+  > "$target_payload"
+
+TARGET_RESULT=$(gh api graphql --input "$target_payload" 2>&1) || {
+  echo "link-dependency $ERR_TARGET_NODE_LOOKUP error: target node ID lookup failed — $TARGET_RESULT" >&2
+  exit 1
+}
+
+TARGET_NODE_ID=$(echo "$TARGET_RESULT" | jq -r '.data.repository.issue.id // empty')
+
+if [ -z "$TARGET_NODE_ID" ]; then
+  echo "link-dependency $ERR_EMPTY_TARGET_NODE_ID error: could not resolve node ID for target issue #$target_number in $target_owner/$target_repo" >&2
+  exit 1
+fi
+
+# --- Step 3: Call addBlockedBy mutation ---
+# Map relationship to addBlockedBy argument order:
+#   blocked-by:  subject IS blocked BY target   → issueId=subject, blockingIssueId=target
+#   is-blocking: subject IS blocking target     → issueId=target, blockingIssueId=subject
+if [ "$relationship" = "blocked-by" ]; then
+  issue_id="$SUBJECT_NODE_ID"
+  blocking_id="$TARGET_NODE_ID"
+  label="blocked #$subject_number ← #$target_number"
+else
+  issue_id="$TARGET_NODE_ID"
+  blocking_id="$SUBJECT_NODE_ID"
+  label="blocking #$subject_number → #$target_number"
+fi
+
+jq -n \
+  --arg issueId "$issue_id" \
+  --arg blockingId "$blocking_id" \
+  '{"query": "mutation($issueId: ID!, $blockingId: ID!) { addBlockedBy(input: {issueId: $issueId, blockingIssueId: $blockingId}) { issue { number } blockingIssue { number } } }", "variables": {"issueId": $issueId, "blockingId": $blockingId}}' \
+  > "$mutation_payload"
+
+RESULT=$(gh api graphql --input "$mutation_payload" 2>&1) || {
+  echo "link-dependency $ERR_MUTATION error: addBlockedBy mutation failed — $RESULT" >&2
+  exit 1
+}
+
+# Check for GraphQL-level errors in the response
+ERRORS=$(echo "$RESULT" | jq -r '.errors[0].message // empty')
+if [ -n "$ERRORS" ]; then
+  echo "link-dependency $ERR_MUTATION error: $ERRORS" >&2
+  exit 1
+fi
+
+echo "$label"


### PR DESCRIPTION
## Summary

/`create-github-issue` now infers dependency relationships from natural language in issue drafts and creates native `addBlockedBy` links at creation time. A new `/add-github-dependency` skill adds dependencies to existing issues post-creation. Both are backed by a unified `link-dependency.sh` script that works cross-repo via GitHub's globally-unique node IDs.

## Changes

- New `/add-github-dependency` skill: accepts a relationship type (`blocked-by` or `is-blocking`) and target URL, then calls `link-dependency.sh` to create the native dependency link via GitHub's `addBlockedBy` mutation. Works from any context on any existing issue
- `/create-github-issue` now interprets dependency relationships expressed naturally in issue drafts ("depends on", "blocked by", "waiting on", "this blocks", "unblocks", etc.) and creates links at issue creation time. No required phrasing. Cross-references `/add-github-dependency` for post-creation workflows
- Unified `link-dependency.sh` script shared by both skills: 14 distinct error codes covering parameter validation (E001–E107) and runtime failures (E200–E204), handles same-repo and cross-repo through the same code path, uses `jq -n` for safe GraphQL payload construction
- 25 bats tests covering all 14 error codes, both success paths (blocked-by same-repo, is-blocking cross-repo), and gh api mocking for all five runtime failure modes
- Documentation: README updated with `/add-github-dependency` in the invocable skills table; CHANGELOG entries under 2026.07.14.3 (Added and Changed)

## Key Discoveries

- Natural language inference replaced the initial literal pattern-matching approach (`Blocked by <URL>`, `Is blocking <URL>`) after realizing users shouldn't need to learn magic strings to express dependencies
- Test coverage audit caught a code smell: self-dependency validation overloaded E201 (target node lookup failure). Extracted to its own error code (E107) in the validation range
- Runtime error codes (E200–E204) needed `gh api` mocking. Adapted the counter-based mock-gh pattern from `update-project-status.bats` with env-var-controlled failure dispatch

## Test Plan

- [x] All 268 existing tests pass
- [x] 25 new tests for link-dependency.sh: all 14 error codes, both success paths, gh api failure modes
- [ ] Manual testing: create an issue with a dependency expressed naturally (e.g., "this depends on https://github.com/other/repo/issues/42"), verify the link appears in GitHub UI

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/182

Generated by /finish-issue v2026.07.10@f41d9bc • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating native GitHub issue dependency links, including cross-repository relationships.
  * Added the `/add-github-dependency` command for marking issues as blocked by or blocking another issue.
  * Issue creation now detects dependency relationships described in issue drafts and links them automatically.
* **Documentation**
  * Updated the changelog and command reference with dependency-linking guidance.
* **Bug Fixes**
  * Added validation and clear error reporting for invalid, missing, self-referential, or failed dependency links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->