### PR TITLE
[issues/205] `resolve-target.sh`: fix stale markers, silent fallback, and mode classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
-## 2026.07.21
+## 2026.07.22
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Contributors are encouraged to add a changelog entry with their PR, but it's not
 
 ### Fixed
 
-- `resolve-target.sh`: use `gh pr list` as authoritative source for stacked PR base refs, fix mode classification regex to handle `origin/issues/*` targets, and error on stale base-branch markers instead of silently falling back to `origin/main` ([issues/205](https://github.com/couimet/my-claude-skills/issues/205))
+- `resolve-target.sh`: use `gh pr list` as authoritative source for stacked PR base refs, classify all non-main/master targets as stacked mode (including custom branches like `origin/issues/*`), and error on stale base-branch markers instead of silently falling back to `origin/main` ([issues/205](https://github.com/couimet/my-claude-skills/issues/205))
 
 ## 2026.07.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.07.21
+
+### Fixed
+
+- `resolve-target.sh`: use `gh pr list` as authoritative source for stacked PR base refs, fix mode classification regex to handle `origin/issues/*` targets, and error on stale base-branch markers instead of silently falling back to `origin/main` ([issues/205](https://github.com/couimet/my-claude-skills/issues/205))
+
 ## 2026.07.19
 
 ### Changed

--- a/bats-tests/resolve-target.bats
+++ b/bats-tests/resolve-target.bats
@@ -184,6 +184,86 @@ setup_remote_with_branch() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"MODE=normal"* ]]
 }
+@test "origin/issues/200 → MODE=stacked" {
+  run "$SCRIPT" "42" "origin/issues/200"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"MODE=stacked"* ]]
+}
+
+@test "origin/issues/123-some-feature → MODE=stacked" {
+  run "$SCRIPT" "42" "origin/issues/123-some-feature"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"MODE=stacked"* ]]
+}
+
+# ============================================================================
+# Auto-resolution: gh pr list
+# ============================================================================
+
+@test "gh pr list returns base ref → TARGET=origin/<base>, MODE=stacked, marker updated" {
+  setup_remote_with_branch "main"
+
+  gh() {
+    if [[ "$1" == "pr" && "$2" == "list" ]]; then
+      echo 'issues/233-layer-one'
+    fi
+  }
+  export -f gh
+
+  run "$SCRIPT" "42"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TARGET=origin/issues/233-layer-one"* ]]
+  [[ "$output" == *"MODE=stacked"* ]]
+
+  local marker_file="$TEST_TEMP_DIR/.claude-work/issues/42/base-branch"
+  [ -f "$marker_file" ]
+  [ "$(cat "$marker_file")" = "origin/issues/233-layer-one" ]
+}
+
+@test "gh pr list returns base ref with origin/ prefix → no double prefix" {
+  setup_remote_with_branch "main"
+
+  gh() {
+    if [[ "$1" == "pr" && "$2" == "list" ]]; then
+      echo 'origin/issues/233-layer-one'
+    fi
+  }
+  export -f gh
+
+  run "$SCRIPT" "42"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TARGET=origin/issues/233-layer-one"* ]]
+  [[ "$output" != *"origin/origin/"* ]]
+}
+
+@test "gh pr list returns empty → falls through to marker" {
+  local marker_dir="$TEST_TEMP_DIR/.claude-work/issues/42"
+  write_file "$marker_dir/base-branch" "issues/100"
+
+  setup_remote_with_branch "issues/100"
+
+  gh() {
+    return 0
+  }
+  export -f gh
+
+  run "$SCRIPT" "42"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TARGET=issues/100"* ]]
+  [[ "$output" == *"MODE=stacked"* ]]
+}
+
+@test "gh pr list not available → falls through to marker" {
+  local marker_dir="$TEST_TEMP_DIR/.claude-work/issues/42"
+  write_file "$marker_dir/base-branch" "issues/100"
+
+  setup_remote_with_branch "issues/100"
+
+  run "$SCRIPT" "42"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TARGET=issues/100"* ]]
+  [[ "$output" == *"MODE=stacked"* ]]
+}
 
 # ============================================================================
 # Auto-resolution: base-branch marker
@@ -224,19 +304,31 @@ setup_remote_with_branch() {
   [[ "$output" == *"MODE=stacked"* ]]
 }
 
-@test "marker has issues/ branch, no remote → fallback to origin/main, MODE=normal" {
+@test "marker has origin/issues/100, remote ref exists → TARGET=origin/issues/100, MODE=stacked" {
+  local marker_dir="$TEST_TEMP_DIR/.claude-work/issues/42"
+  write_file "$marker_dir/base-branch" "origin/issues/100"
+
+  setup_remote_with_branch "issues/100"
+
+  run "$SCRIPT" "42"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TARGET=origin/issues/100"* ]]
+  [[ "$output" == *"MODE=stacked"* ]]
+}
+
+@test "marker has issues/ branch, no remote → error T004" {
   local marker_dir="$TEST_TEMP_DIR/.claude-work/issues/42"
   write_file "$marker_dir/base-branch" "issues/100"
 
   # No remote configured — git ls-remote origin will fail.
 
   run "$SCRIPT" "42"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"TARGET=origin/main"* ]]
-  [[ "$output" == *"MODE=normal"* ]]
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"T004"* ]]
+  [[ "$output" == *"no longer exists on remote"* ]]
 }
 
-@test "marker has issues/ branch, remote exists but ref absent → fallback to origin/main" {
+@test "marker has issues/ branch, remote exists but ref absent → error T004" {
   local marker_dir="$TEST_TEMP_DIR/.claude-work/issues/42"
   write_file "$marker_dir/base-branch" "issues/999"
 
@@ -245,9 +337,9 @@ setup_remote_with_branch() {
   setup_remote_with_branch "issues/100"
 
   run "$SCRIPT" "42"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"TARGET=origin/main"* ]]
-  [[ "$output" == *"MODE=normal"* ]]
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"T004"* ]]
+  [[ "$output" == *"no longer exists on remote"* ]]
 }
 
 @test "marker has origin/main base → MODE=normal (not an issues/ ref)" {
@@ -277,7 +369,7 @@ setup_remote_with_branch() {
   [[ "$output" == *"MODE=normal"* ]]
 }
 
-@test "marker has origin/feature-branch, remote ref absent → fallback to origin/main" {
+@test "marker has origin/feature-branch, remote ref absent → error T004" {
   local marker_dir="$TEST_TEMP_DIR/.claude-work/issues/42"
   write_file "$marker_dir/base-branch" "origin/nonexistent"
 
@@ -285,9 +377,9 @@ setup_remote_with_branch() {
   setup_remote_with_branch "main"
 
   run "$SCRIPT" "42"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"TARGET=origin/main"* ]]
-  [[ "$output" == *"MODE=normal"* ]]
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"T004"* ]]
+  [[ "$output" == *"no longer exists on remote"* ]]
 }
 
 # ============================================================================

--- a/bats-tests/resolve-target.bats
+++ b/bats-tests/resolve-target.bats
@@ -253,6 +253,23 @@ setup_remote_with_branch() {
   [[ "$output" == *"MODE=stacked"* ]]
 }
 
+@test "gh pr list returns literal null → falls through to marker" {
+  local marker_dir="$TEST_TEMP_DIR/.claude-work/issues/42"
+  write_file "$marker_dir/base-branch" "issues/100"
+
+  setup_remote_with_branch "issues/100"
+
+  gh() {
+    echo 'null'
+  }
+  export -f gh
+
+  run "$SCRIPT" "42"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TARGET=issues/100"* ]]
+  [[ "$output" == *"MODE=stacked"* ]]
+}
+
 @test "gh pr list not available → falls through to marker" {
   local marker_dir="$TEST_TEMP_DIR/.claude-work/issues/42"
   write_file "$marker_dir/base-branch" "issues/100"
@@ -375,6 +392,24 @@ setup_remote_with_branch() {
 
   # origin exists but does NOT have a branch named "nonexistent".
   setup_remote_with_branch "main"
+
+  run "$SCRIPT" "42"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"T004"* ]]
+  [[ "$output" == *"no longer exists on remote"* ]]
+}
+
+@test "marker ref matches a tag but not a branch → error T004" {
+  local marker_dir="$TEST_TEMP_DIR/.claude-work/issues/42"
+  write_file "$marker_dir/base-branch" "issues/100"
+
+  # Create a bare remote and push only a tag (no branch) named issues/100.
+  local bare_repo="$TEST_TEMP_DIR/bare-remote.git"
+  git init --bare -q "$bare_repo"
+  git remote add origin "$bare_repo"
+
+  git tag "issues/100" main
+  git push -q origin "refs/tags/issues/100" 2>/dev/null
 
   run "$SCRIPT" "42"
   [ "$status" -eq 1 ]

--- a/bats-tests/resolve-target.bats
+++ b/bats-tests/resolve-target.bats
@@ -173,16 +173,16 @@ setup_remote_with_branch() {
   [[ "$output" == *"MODE=normal"* ]]
 }
 
-@test "issues without a digit → MODE=normal" {
+@test "issues/foo (non-numeric) → MODE=stacked" {
   run "$SCRIPT" "42" "issues/foo"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"MODE=normal"* ]]
+  [[ "$output" == *"MODE=stacked"* ]]
 }
 
-@test "nested issues/ path → MODE=normal (only anchored matches count)" {
+@test "feature/issues/200 → MODE=stacked (any non-main/master target is stacked)" {
   run "$SCRIPT" "42" "feature/issues/200"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"MODE=normal"* ]]
+  [[ "$output" == *"MODE=stacked"* ]]
 }
 @test "origin/issues/200 → MODE=stacked" {
   run "$SCRIPT" "42" "origin/issues/200"
@@ -192,6 +192,12 @@ setup_remote_with_branch() {
 
 @test "origin/issues/123-some-feature → MODE=stacked" {
   run "$SCRIPT" "42" "origin/issues/123-some-feature"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"MODE=stacked"* ]]
+}
+
+@test "origin/issues/side-quest (non-numeric) → MODE=stacked" {
+  run "$SCRIPT" "42" "origin/issues/side-quest"
   [ "$status" -eq 0 ]
   [[ "$output" == *"MODE=stacked"* ]]
 }
@@ -372,7 +378,7 @@ setup_remote_with_branch() {
   [[ "$output" == *"MODE=normal"* ]]
 }
 
-@test "marker has origin/feature-branch, remote ref exists → use base-branch" {
+@test "marker has origin/feature-branch, remote ref exists → use base-branch, MODE=stacked" {
   local marker_dir="$TEST_TEMP_DIR/.claude-work/issues/42"
   write_file "$marker_dir/base-branch" "origin/my-feature"
 
@@ -383,7 +389,7 @@ setup_remote_with_branch() {
   run "$SCRIPT" "42"
   [ "$status" -eq 0 ]
   [[ "$output" == *"TARGET=origin/my-feature"* ]]
-  [[ "$output" == *"MODE=normal"* ]]
+  [[ "$output" == *"MODE=stacked"* ]]
 }
 
 @test "marker has origin/feature-branch, remote ref absent → error T004" {

--- a/skills/README.md
+++ b/skills/README.md
@@ -42,6 +42,7 @@ Non-invocable skills (`user-invocable: false`) don't appear in the `/` menu. The
 | `finish-issue` | `/finish-issue [optional: issue-number-or-url]` | `/note`, `/question`, breadcrumbs (reads); handles both `issues/*` and `side-quest/*` branches |
 | `start-issue` | `/start-issue <url> [--scratchpad]` | `/note` (default), `/scratchpad` (opt-in), `/question`, `/cleanup-issue` |
 | `start-side-quest` | `/start-side-quest <desc> [--scratchpad]` | `/note` (default), `/scratchpad` (opt-in), `/question`, `/commit-msg` (ref) |
+| `rebase-issue` | `/rebase-issue [target]` | `resolve-target.sh`, `apply-stacked-diff.sh`, `resolve-commit-msg.sh` |
 | `tackle-pr-comment` | `/tackle-pr-comment <url> [--scratchpad]` | `/note` (default), `/scratchpad` (opt-in), `/question`, `/commit-msg` |
 | `tackle-scratchpad-block` | `/tackle-scratchpad-block <path#lines>` | `/scratchpad-ref-format`, `/question`, `/commit-msg`, `/scratchpad` (reads) |
 

--- a/skills/rebase-issue/SKILL.md
+++ b/skills/rebase-issue/SKILL.md
@@ -4,7 +4,7 @@ version: 2026.07.19@1a9d2a6
 description: Rebase the current issue branch onto origin/main (or a specified target) after upstream PRs merge. Handles conflict resolution, squashes to a single commit, and runs autonomously
 argument-hint: <target>
 user-invocable: true
-allowed-tools: Read, Write, AskUserQuestion, Bash(git branch --show-current), Bash(git fetch *), Bash(git log *), Bash(git diff *), Bash(git rebase *), Bash(git reset *), Bash(git commit *), Bash(git add *), Bash(git checkout *), Bash(git merge-base *), Bash(git rev-parse *), Bash(git status *), Bash(*/skills/issue-context/claude-work-root.sh *), Bash(*/skills/rebase-issue/resolve-target.sh *), Bash(*/skills/rebase-issue/apply-stacked-diff.sh *), Bash(*/skills/rebase-issue/resolve-commit-msg.sh *)
+allowed-tools: Read, Write, AskUserQuestion, Bash(git branch --show-current), Bash(git fetch *), Bash(git log *), Bash(git diff *), Bash(git rebase *), Bash(git reset *), Bash(git commit *), Bash(git add *), Bash(git checkout *), Bash(git merge-base *), Bash(git rev-parse *), Bash(git status *), Bash(gh pr list *), Bash(*/skills/issue-context/claude-work-root.sh *), Bash(*/skills/rebase-issue/resolve-target.sh *), Bash(*/skills/rebase-issue/apply-stacked-diff.sh *), Bash(*/skills/rebase-issue/resolve-commit-msg.sh *)
 ---
 
 # Rebase Issue
@@ -42,7 +42,7 @@ Run the target resolution script:
 ~/.claude/skills/rebase-issue/resolve-target.sh <NUMBER> [$ARGUMENTS]
 ```
 
-The script resolves the target from the explicit argument (if provided), the base-branch marker file, or falls back to `origin/main`. It outputs two lines:
+The script resolves the target from the explicit argument (if provided), `gh pr list` (authoritative for PR stacking relationships), the base-branch marker file, or falls back to `origin/main`. It outputs two lines:
 
 ```text
 TARGET=<ref>
@@ -188,7 +188,7 @@ When `git rebase` encounters conflicts during Step 8, apply this strategy:
 ## Edge Cases
 
 - **No upstream changes:** `HEAD..<target>` is empty. Nothing to rebase -- report and exit at Step 4.
-- **Stacked PRs:** when the base-branch marker file records another `issues/*` branch that still exists remotely, `git rebase` is replaced with a diff-apply via `apply-stacked-diff.sh` (Step 7). The script captures only the unique stacked diff, avoiding contamination from old commits whose changes already exist in the squashed base. When the recorded base branch disappears from the remote (PR merged and branch deleted), the stacked branch automatically graduates to targeting `origin/main` in normal rebase mode. Classification is handled uniformly by `resolve-target.sh` — any target matching `issues/*` (whether from an explicit argument or auto-resolution) uses stacked mode.
+- **Stacked PRs:** when the base-branch marker file records another `issues/*` branch that still exists remotely, `git rebase` is replaced with a diff-apply via `apply-stacked-diff.sh` (Step 7). The script captures only the unique stacked diff, avoiding contamination from old commits whose changes already exist in the squashed base. When the recorded base branch disappears from the remote (PR merged and branch deleted), `resolve-target.sh` exits with a `T004` error telling the user the marker is stale. The user must specify an explicit target via `/rebase-issue <target>`. Classification is handled uniformly by `resolve-target.sh` — any target matching `issues/*` (whether from an explicit argument or auto-resolution) uses stacked mode.
 - **Diff apply conflicts:** when `git apply --reject` fails in stacked mode, `.rej` files and the patch file are preserved for manual resolution. The diff is limited to the stacked branch's unique changes, so conflicts are narrow and focused.
 - **Clean rebase:** `git rebase <target>` completes with no conflicts. Proceed directly to Step 9.
 - **Unresolvable conflicts:** abort with `git rebase --abort` and ask the user.

--- a/skills/rebase-issue/SKILL.md
+++ b/skills/rebase-issue/SKILL.md
@@ -50,7 +50,7 @@ MODE=<stacked|normal>
 ```
 
 - `TARGET` is the git ref to rebase onto (e.g., `origin/main`, `issues/200`).
-- `MODE` is `stacked` when the target is an `issues/*` branch, `normal` otherwise. This classification applies uniformly whether the target came from an explicit argument or auto-resolution.
+- `MODE` is `stacked` by default (any feature branch), `normal` only for long-lived base branches (`main`, `master`). This classification applies uniformly whether the target came from an explicit argument or auto-resolution. The logic makes no assumptions about branch naming conventions — side-quests, custom branches, and any future naming scheme all get stacked diff-apply.
 
 Use these values throughout the remaining steps.
 
@@ -188,7 +188,7 @@ When `git rebase` encounters conflicts during Step 8, apply this strategy:
 ## Edge Cases
 
 - **No upstream changes:** `HEAD..<target>` is empty. Nothing to rebase -- report and exit at Step 4.
-- **Stacked PRs:** when the base-branch marker file records another `issues/*` branch that still exists remotely, `git rebase` is replaced with a diff-apply via `apply-stacked-diff.sh` (Step 7). The script captures only the unique stacked diff, avoiding contamination from old commits whose changes already exist in the squashed base. When the recorded base branch disappears from the remote (PR merged and branch deleted), `resolve-target.sh` exits with a `T004` error telling the user the marker is stale. The user must specify an explicit target via `/rebase-issue <target>`. Classification is handled uniformly by `resolve-target.sh` — any target matching `issues/*` (whether from an explicit argument or auto-resolution) uses stacked mode.
+- **Stacked PRs:** when the base-branch marker file records a feature branch that still exists remotely, `git rebase` is replaced with a diff-apply via `apply-stacked-diff.sh` (Step 7). The script captures only the unique stacked diff, avoiding contamination from old commits whose changes already exist in the squashed base. When the recorded base branch disappears from the remote (PR merged and branch deleted), `resolve-target.sh` exits with a `T004` error telling the user the marker is stale. The user must specify an explicit target via `/rebase-issue <target>`. Classification is handled uniformly by `resolve-target.sh` — any target that is not a long-lived base branch (`main`, `master`) uses stacked mode, regardless of naming convention.
 - **Diff apply conflicts:** when `git apply --reject` fails in stacked mode, `.rej` files and the patch file are preserved for manual resolution. The diff is limited to the stacked branch's unique changes, so conflicts are narrow and focused.
 - **Clean rebase:** `git rebase <target>` completes with no conflicts. Proceed directly to Step 9.
 - **Unresolvable conflicts:** abort with `git rebase --abort` and ask the user.

--- a/skills/rebase-issue/resolve-target.sh
+++ b/skills/rebase-issue/resolve-target.sh
@@ -91,7 +91,7 @@ else
   current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" || true
   if [ -n "$current_branch" ] && command -v gh >/dev/null 2>&1; then
     base_ref="$(gh pr list --head "$current_branch" --json baseRefName --jq '.[0].baseRefName' 2>/dev/null)" || true
-    if [ -n "$base_ref" ]; then
+    if [ -n "$base_ref" ] && [ "$base_ref" != "null" ]; then
       # Guard against double origin/ prefix.
       if [[ "$base_ref" != origin/* ]]; then
         base_ref="origin/${base_ref}"
@@ -112,7 +112,7 @@ else
         # Strip origin/ prefix for the ls-remote check — ls-remote expects
         # bare branch names (e.g., "main", not "origin/main").
         check_ref="${base_branch#origin/}"
-        if git ls-remote origin "$check_ref" 2>/dev/null | grep -q .; then
+        if git ls-remote origin "refs/heads/$check_ref" 2>/dev/null | grep -q .; then
           # Base PR hasn't been merged yet — rebase onto it.
           # Use the original value so the origin/ prefix is preserved in the target.
           target="$base_branch"

--- a/skills/rebase-issue/resolve-target.sh
+++ b/skills/rebase-issue/resolve-target.sh
@@ -3,8 +3,8 @@
 # resolve-target.sh — Resolve the rebase target ref and mode (normal or stacked)
 # for an issue branch. The target comes from an explicit argument, gh pr list
 # (authoritative for PR stacking relationships), the base-branch marker file,
-# or a fallback to origin/main. Mode is classified uniformly as stacked when
-# the target matches issues/*, normal otherwise.
+# or a fallback to origin/main. Mode is classified as stacked by default,
+# normal only for long-lived base branches (main, master).
 #
 # Usage: resolve-target.sh <issue-number> [explicit-target]
 #
@@ -134,10 +134,10 @@ fi
 
 # --- Classify mode ---
 
-mode="normal"
+mode="stacked"
 bare_target="${target#origin/}"
-if [[ "$bare_target" =~ ^issues/[0-9] ]]; then
-  mode="stacked"
+if [[ "$bare_target" == "main" ]] || [[ "$bare_target" == "master" ]]; then
+  mode="normal"
 fi
 
 # --- Output ---

--- a/skills/rebase-issue/resolve-target.sh
+++ b/skills/rebase-issue/resolve-target.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 #
 # resolve-target.sh — Resolve the rebase target ref and mode (normal or stacked)
-# for an issue branch. The target comes from an explicit argument, the
-# base-branch marker file, or a fallback to origin/main. Mode is classified
-# uniformly as stacked when the target matches issues/*, normal otherwise.
+# for an issue branch. The target comes from an explicit argument, gh pr list
+# (authoritative for PR stacking relationships), the base-branch marker file,
+# or a fallback to origin/main. Mode is classified uniformly as stacked when
+# the target matches issues/*, normal otherwise.
 #
 # Usage: resolve-target.sh <issue-number> [explicit-target]
 #
@@ -22,12 +23,14 @@
 #   T001 — wrong number of arguments
 #   T002 — invalid issue number
 #   T003 — claude-work-root.sh failed
+#   T004 — base-branch marker ref no longer exists on remote
 
 set -euo pipefail
 
 readonly ERR_ARGS="T001"
 readonly ERR_INVALID_ISSUE="T002"
 readonly ERR_CLAUDE_ROOT="T003"
+readonly ERR_STALE_MARKER="T004"
 
 usage() {
   cat <<'EOF'
@@ -80,25 +83,50 @@ if [ -n "$explicit_target" ]; then
   # Explicit argument always wins.
   target="$explicit_target"
 else
-  # Auto-resolve from base-branch marker.
+  # Auto-resolve from gh pr list (authoritative) or base-branch marker.
   marker_file="${claude_work_root}/issues/${issue_number}/base-branch"
 
-  if [ -f "$marker_file" ] && [ -r "$marker_file" ] && [ -s "$marker_file" ]; then
-    base_branch="$(head -n1 "$marker_file" | tr -d '\n')"
+  # First, try gh pr list as the authoritative source. The GitHub PR owns the
+  # stacking relationship. gh may not be available (tests), so guard with command -v.
+  current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" || true
+  if [ -n "$current_branch" ] && command -v gh >/dev/null 2>&1; then
+    base_ref="$(gh pr list --head "$current_branch" --json baseRefName --jq '.[0].baseRefName' 2>/dev/null)" || true
+    if [ -n "$base_ref" ]; then
+      # Guard against double origin/ prefix.
+      if [[ "$base_ref" != origin/* ]]; then
+        base_ref="origin/${base_ref}"
+      fi
+      target="$base_ref"
+      # Update the marker file so it stays current.
+      mkdir -p "$(dirname "$marker_file")"
+      printf '%s' "$base_ref" > "$marker_file"
+    fi
+  fi
 
-    if [ -n "$base_branch" ]; then
-      # Strip origin/ prefix for the ls-remote check — ls-remote expects
-      # bare branch names (e.g., "main", not "origin/main").
-      check_ref="${base_branch#origin/}"
-      if git ls-remote origin "$check_ref" 2>/dev/null | grep -q .; then
-        # Base PR hasn't been merged yet — rebase onto it.
-        # Use the original value so the origin/ prefix is preserved in the target.
-        target="$base_branch"
+  # If gh pr list didn't resolve, fall back to the marker file.
+  if [ -z "$target" ]; then
+    if [ -f "$marker_file" ] && [ -r "$marker_file" ] && [ -s "$marker_file" ]; then
+      base_branch="$(head -n1 "$marker_file" | tr -d '\n')"
+
+      if [ -n "$base_branch" ]; then
+        # Strip origin/ prefix for the ls-remote check — ls-remote expects
+        # bare branch names (e.g., "main", not "origin/main").
+        check_ref="${base_branch#origin/}"
+        if git ls-remote origin "$check_ref" 2>/dev/null | grep -q .; then
+          # Base PR hasn't been merged yet — rebase onto it.
+          # Use the original value so the origin/ prefix is preserved in the target.
+          target="$base_branch"
+        else
+          # Remote ref no longer exists — the upstream branch was likely
+          # merged and deleted. The marker is stale; don't guess.
+          echo "resolve-target $ERR_STALE_MARKER error: base-branch marker points to '$base_branch' which no longer exists on remote. The upstream branch was likely merged and deleted. Run '/rebase-issue <new-target>' to specify the correct target, or update the marker file at '$marker_file'." >&2
+          exit 1
+        fi
       fi
     fi
   fi
 
-  # Fallback if marker was missing, empty, or the remote ref is gone.
+  # Fallback if no marker exists and gh pr list returned nothing.
   if [ -z "$target" ]; then
     target="origin/main"
   fi
@@ -107,7 +135,8 @@ fi
 # --- Classify mode ---
 
 mode="normal"
-if [[ "$target" =~ ^issues/[0-9] ]]; then
+bare_target="${target#origin/}"
+if [[ "$bare_target" =~ ^issues/[0-9] ]]; then
   mode="stacked"
 fi
 


### PR DESCRIPTION
## Summary

`resolve-target.sh` had three bugs that broke stacked PR rebasing. It never queried `gh pr list` for the authoritative base ref, so stacked relationships recorded only in GitHub were invisible. When a base-branch marker pointed to a deleted branch, it silently fell back to `origin/main` instead of telling the user. And the mode classification regex `^issues/[0-9]` never matched targets with the `origin/` prefix stored in marker files, so stacked branches always classified as `MODE=normal` and bypassed `apply-stacked-diff.sh`.

## Changes

- Rebasing a stacked PR now queries `gh pr list` for the authoritative base ref, with double `origin/` prefix guard and automatic marker file update to prevent staleness (via `skills/rebase-issue/resolve-target.sh`)
- Base-branch markers that point to deleted remote branches now produce a clear `T004` error instead of silently falling back to `origin/main`, preventing incorrect rebases onto the wrong target
- Stacked PR mode detection now handles `origin/issues/*` targets by stripping `origin/` before regex matching — previously only bare `issues/*` matched, causing all stacked branches to bypass `apply-stacked-diff.sh`
- `rebase-issue/SKILL.md` allowed-tools updated with `Bash(gh pr list *)`; edge case docs updated for the new error behavior

## Key Discoveries

- The mode classification bug (comment #5039067564) was a second-order effect of storing `origin/` prefixed values in the marker file, added in [#202](https://github.com/couimet/my-claude-skills/issues/202). The regex was never updated to match.
- The silent `origin/main` fallback was the only remaining "trust the marker or give up" path in the script. Removing it makes all resolution paths explicit: gh pr, valid marker, or user-specified target.

## Test Plan

- [ ] All 37 `resolve-target.bats` tests pass
- [ ] New tests added for: `origin/` prefix mode classification (2 tests), `gh pr list` mock resolution with marker update (4 tests), `T004` stale marker error (3 tests modified from silent-fallback expectations)
- [ ] Manual testing: create a stacked PR, merge the base branch, verify `/rebase-issue` reports T004 instead of rebasing onto `origin/main`

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/205

Generated by /finish-issue v2026.07.19@1a9d2a6 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic rebase target detection by using pull request base references.
  * Stacked targets now correctly recognize `origin/issues/...`.
  * When the saved base-branch marker is stale (no longer exists on the remote), the command now fails with `T004` instead of falling back to the main branch.
* **Documentation**
  * Updated `/rebase-issue` and target-resolution guidance, including the new stale-marker and `MODE` classification behavior.
* **Tests**
  * Expanded coverage for `gh pr list` resolution, missing tooling, `origin/`-prefixed issue targets, and stale marker failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->