### PR TITLE
[issues/207] Add skills to Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace-manifest.json",
+  "name": "my-claude-skills",
+  "owner": {
+    "name": "couimet",
+    "url": "https://github.com/couimet"
+  },
+  "description": "A collection of portable Claude Code skills for structured development workflows.",
+  "plugins": [
+    {
+      "name": "my-claude-skills",
+      "source": "./",
+      "description": "Portable Claude Code skills for structured development workflows — issue tracking, PR feedback, plan-driven implementation, and more. Includes /start-issue, /finish-issue, /scratchpad, /note, /question, /commit-msg, /rebase-issue, and more.",
+      "license": "MIT",
+      "keywords": ["workflow", "issue-tracking", "code-review", "planning", "skills", "development"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "my-claude-skills",
+  "description": "A collection of portable Claude Code skills for structured development workflows — issue tracking, PR feedback, plan-driven implementation, and more.",
+  "author": {
+    "name": "Charles Ouimet",
+    "url": "https://github.com/couimet"
+  },
+  "homepage": "https://github.com/couimet/my-claude-skills",
+  "repository": "https://github.com/couimet/my-claude-skills",
+  "license": "MIT",
+  "keywords": ["workflow", "issue-tracking", "code-review", "planning", "skills", "development"],
+  "skills": ["./skills"]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.07.27
+
+### Added
+
+- Added Claude Code marketplace support via `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`, making skills installable through `/plugin marketplace add couimet/my-claude-skills` and `/plugin install my-claude-skills@my-claude-skills` as an alternative to the direct `git clone` + `install.sh` workflow ([issues/207](https://github.com/couimet/my-claude-skills/issues/207))
+
 ## 2026.07.22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -26,6 +26,29 @@ cd ~/src/my-claude-skills && git pull && ./install.sh
 
 The install script is idempotent — safe to run on every pull. It only creates/updates symlinks; it never deletes non-symlink directories.
 
+### Marketplace Installation
+
+As an alternative to the direct install, the [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugins) lets you install these skills as a plugin. Skills are namespaced under the plugin name when installed this way, so they must be invoked with a prefix instead of their bare name.
+
+```bash
+/plugin marketplace add couimet/my-claude-skills
+/plugin install my-claude-skills@my-claude-skills
+```
+
+The `@` separates plugin name from marketplace name (`plugin@marketplace`). Here they happen to be the same. Prefer the [direct install](#installation) if you want shorter invocation names — marketplace-installed skills are namespaced (`/my-claude-skills:start-issue`), while symlink-installed skills keep their bare names (`/start-issue`).
+
+Once installed, invoke any skill with the plugin prefix:
+
+```text
+/my-claude-skills:start-issue https://github.com/...
+```
+
+To update:
+
+```text
+/plugin update my-claude-skills
+```
+
 ## Quick Start
 
 Once installed, try these in any project:


### PR DESCRIPTION
## Summary

This adds marketplace support so the skills can be discovered and installed through Claude Code's plugin system. The self-hosted marketplace at `couimet/my-claude-skills` works today. Community marketplace submission (for discoverability without adding a custom marketplace) is the next step once this merges.

## Changes

- New plugin manifest at `.claude-plugin/plugin.json` describes `my-claude-skills` as a bundled plugin with all skills, validated with `claude plugin validate` (passes; `version` field intentionally omitted — commit SHA is used instead)
- New marketplace listing at `.claude-plugin/marketplace.json` registers the repo as a self-hosted marketplace so users can install with `/plugin marketplace add couimet/my-claude-skills` followed by `/plugin install my-claude-skills@my-claude-skills`
- README now includes a "Marketplace Installation" subsection under Installation showing both the direct and marketplace paths, with an explanation of the `plugin@marketplace` syntax and when to prefer each path
- Documentation: CHANGELOG updated
- Community marketplace submission: validated and ready. Post-merge, submit via https://clau.de/plugin-directory-submission. Once approved, users install with `/plugin install my-claude-skills@claude-community` with no marketplace-add step needed

## Key Discoveries

- The `skills` field in plugin.json must use array format (`["./skills"]`) — the bare string form `"skills"` passes Prettier but is rejected by `claude plugin validate`
- Plugin names are immutable slugs with no user-side alias mechanism. Users who want short invocation names should use the direct symlink install
- The community marketplace name `my-claude-skills` is not taken. The `couimet/` owner prefix provides marketplace-level namespacing, and plugin-level collision is unlikely for a personal collection

## Test Plan

- [x] `make lint` passes (markdownlint, Prettier, shellcheck)
- [x] `make test` passes (12 pre-existing failures in `apply-stacked-diff.bats`, unrelated)
- [x] `claude plugin validate` passes
- [ ] Manual: install via `/plugin marketplace add couimet/my-claude-skills` and verify `/my-claude-skills:start-issue` works
- [ ] Post-merge: submit to community marketplace via https://clau.de/plugin-directory-submission

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/207

Generated by /finish-issue v2026.07.22@9fcae14 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for installing the Claude Code skills through a marketplace.
  - Added marketplace and plugin metadata, including descriptions, licensing, keywords, and skill locations.

- **Documentation**
  - Added installation instructions for marketplace-based setup.
  - Documented plugin and marketplace naming, invocation options, and update commands.
  - Added changelog details covering the new installation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->