### PR TITLE
[issues/213] Stop printing internal pointer paths in skill terminal output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Entries are organized using [Keep a Changelog](https://keepachangelog.com/) cate
 
 Contributors are encouraged to add a changelog entry with their PR, but it's not required. CI will nudge you with a non-blocking reminder if CHANGELOG.md wasn't modified.
 
+## 2026.07.31
+
+### Changed
+
+- Internal pointer paths (active-plan, last-finish-issue) are no longer printed in `/start-issue`, `/start-side-quest`, and `/finish-issue` terminal output; these are implementation details consumed by downstream skills, not user-actionable paths. "Files created:" sections simplified to direct labels. ([issues/213](https://github.com/couimet/my-claude-skills/issues/213))
+
 ## 2026.07.27
 
 ### Added

--- a/skills/finish-issue/SKILL.md
+++ b/skills/finish-issue/SKILL.md
@@ -243,9 +243,7 @@ Verification:
 - tests: [all pass / X tests, Y passing]
 - uncommitted changes: [none / list]
 
-Files created:
-- <actual-absolute-path-to-pr-description> (PR description)
-- <actual-absolute-path-to-pointer> (last-finish-issue pointer)
+PR description: <actual-absolute-path-to-pr-description>
 
 ---
 
@@ -265,9 +263,7 @@ Verification:
 - tests: [all pass / X tests, Y passing]
 - uncommitted changes: [none / list]
 
-Files created:
-- <actual-absolute-path-to-pr-description> (PR description)
-(last-finish-issue pointer skipped — side-quest mode)
+PR description: <actual-absolute-path-to-pr-description>
 
 ---
 

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -193,7 +193,7 @@ If questions are needed, use `/question` to create a questions file. Add a `**Pl
 
 ## Step 6: Report Status and STOP
 
-Print the branch name, the absolute working-document path, the absolute active-plan pointer path, and any absolute questions file path. Then print a "Next" line that matches the path taken in Step 4:
+Print the branch name, the absolute working-document path, and any absolute questions file path. Then print a "Next" line that matches the path taken in Step 4:
 
 **Default path (note):**
 

--- a/skills/start-side-quest/SKILL.md
+++ b/skills/start-side-quest/SKILL.md
@@ -120,11 +120,9 @@ Print a summary:
 Branch: side-quest/<slug>
 Parent: <original branch> (stashed if had changes)
 
-Files created:
-- <base>/notes/<file>.txt (implementation plan, absolute path, default)
+Plan: <base>/notes/<file>.txt (absolute path, default)
   OR <base>/scratchpads/<file>.txt (if --scratchpad, absolute path)
-- <base>/active-plan-<slug> (absolute path, pointer to the working document)
-- <base>/questions/<file>.txt (if questions needed, absolute path)
+Questions: <base>/questions/<file>.txt (if needed, absolute path)
 
 Stash: <stash message if applicable>
 


### PR DESCRIPTION
## Summary

Skills now write internal pointer files (active-plan, base-branch marker, last-finish-issue) to disk without printing their paths in terminal output. These paths were noise — the user never interacts with them directly, and downstream skills find them on disk automatically. The "Files created:" sections in `/start-side-quest` and `/finish-issue` output are simplified to direct labels now that they no longer enumerate multiple file types.

## Changes

- Internal pointer paths (active-plan, last-finish-issue) removed from terminal output in `/start-issue` Step 6, `/start-side-quest` Step 5, and `/finish-issue` Step 7; these are implementation details, not user-actionable paths
- "Files created:" sections in `/start-side-quest` and `/finish-issue` output replaced with direct labels (`Plan:`, `Questions:`, `PR description:`) now that they contain only user-actionable file paths

## Test Plan

- [ ] All existing tests pass (326 tests)
- [ ] Manual testing: run `/start-issue`, `/start-side-quest`, and `/finish-issue` and verify pointer paths are no longer printed in terminal output

## Related

- Closes https://github.com/couimet/my-claude-skills/issues/213

Generated by /finish-issue v2026.07.27@6dc7d1d • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@coderabbitai ignore